### PR TITLE
chore: Standardize foreign key references and clean up migrations

### DIFF
--- a/app/Models/Core/User.php
+++ b/app/Models/Core/User.php
@@ -78,7 +78,7 @@ class User extends Authenticatable
 
     public function getTable()
     {
-        return env('AUTH_USER_TABLE', 'users');
+        return env('AUTH_USER_TABLE', 'user_management');
     }
 
     /*

--- a/database/migrations/2025_11_19_201255_create_services_table.php
+++ b/database/migrations/2025_11_19_201255_create_services_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('services', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('category_id')->nullable();
+            $table->unsignedBigInteger('category_id')->nullable()->index();
             $table->unsignedBigInteger('sla_id')->nullable()->index();
             // sku (string unique)
             $table->string('sku')->unique();
@@ -99,8 +99,6 @@ return new class extends Migration
 
             //Timestamp
             $table->timestamps();
-
-            $table->foreign('category_id')->references('id')->on('categories')->onDelete('set null');
         });
     }
 

--- a/database/migrations/2026_03_31_155310_create_categories_table.php
+++ b/database/migrations/2026_03_31_155310_create_categories_table.php
@@ -26,6 +26,10 @@ return new class extends Migration
         Schema::table('clients', function (Blueprint $table): void {
             $table->foreign('sales_category_id')->references('id')->on('categories')->nullOnDelete();
         });
+
+        Schema::table('services', function (Blueprint $table): void {
+            $table->foreign('category_id')->references('id')->on('categories')->nullOnDelete();
+        });
     }
 
     /**
@@ -33,6 +37,10 @@ return new class extends Migration
      */
     public function down(): void
     {
+        Schema::table('services', function (Blueprint $table): void {
+            $table->dropForeign(['category_id']);
+        });
+
         Schema::table('clients', function (Blueprint $table): void {
             $table->dropForeign(['sales_category_id']);
         });

--- a/database/migrations/2026_04_07_192649_create_articles_table.php
+++ b/database/migrations/2026_04_07_192649_create_articles_table.php
@@ -21,9 +21,9 @@ return new class extends Migration
             $table->string('status')->default('draft'); // draft, published, archived, needs_review
             $table->foreignId('owner_id')->constrained('user_management');
             $table->foreignId('category_id')->nullable()->constrained('categories')->onDelete('set null');
-            $table->foreignId('knowledge_shelf_id')->nullable()->constrained('knowledge_shelves')->nullOnDelete();
-            $table->foreignId('knowledge_book_id')->nullable()->constrained('knowledge_books')->nullOnDelete();
-            $table->foreignId('knowledge_chapter_id')->nullable()->constrained('knowledge_chapters')->nullOnDelete();
+            $table->unsignedBigInteger('knowledge_shelf_id')->nullable();
+            $table->unsignedBigInteger('knowledge_book_id')->nullable();
+            $table->unsignedBigInteger('knowledge_chapter_id')->nullable();
             $table->foreignId('client_scope_id')->nullable()->constrained('clients');
             $table->unsignedInteger('priority')->default(0);
             $table->integer('view_count')->default(0);

--- a/database/migrations/2026_04_21_152819_create_assets_table.php
+++ b/database/migrations/2026_04_21_152819_create_assets_table.php
@@ -27,9 +27,9 @@ return new class extends Migration
             $table->string('rmm_id')->nullable()->index();
             $table->boolean('is_managed')->default(false);
             $table->string('status')->default('unknown'); // online, offline, unknown, in_service
-            $table->foreignId('user_id')->nullable()->after('site_id')->constrained('client_users')->onDelete('set null');
-            $table->enum('ip_type', ['dhcp', 'fixed'])->default('dhcp')->after('ip_address');
-            $table->foreignId('vendor_id')->nullable()->after('vendor')->constrained('vendors')->onDelete('set null');
+            $table->foreignId('user_id')->nullable()->constrained('client_users')->onDelete('set null');
+            $table->enum('ip_type', ['dhcp', 'fixed'])->default('dhcp');
+            $table->foreignId('vendor_id')->nullable()->constrained('vendors')->onDelete('set null');
             $table->timestamp('last_seen_at')->nullable();
             $table->json('metadata')->nullable();
             $table->timestamps();

--- a/database/migrations/2026_05_14_173958_create_knowledge_chapters_table.php
+++ b/database/migrations/2026_05_14_173958_create_knowledge_chapters_table.php
@@ -33,6 +33,23 @@ return new class extends Migration
             $table->index(['book_id', 'priority']);
             $table->index(['source_system', 'sync_status'], 'knowledge_chapters_source_status_index');
         });
+
+        Schema::table('articles', function (Blueprint $table): void {
+            $table->foreign('knowledge_shelf_id')
+                ->references('id')
+                ->on('knowledge_shelves')
+                ->nullOnDelete();
+
+            $table->foreign('knowledge_book_id')
+                ->references('id')
+                ->on('knowledge_books')
+                ->nullOnDelete();
+
+            $table->foreign('knowledge_chapter_id')
+                ->references('id')
+                ->on('knowledge_chapters')
+                ->nullOnDelete();
+        });
     }
 
     /**
@@ -40,6 +57,12 @@ return new class extends Migration
      */
     public function down(): void
     {
+        Schema::table('articles', function (Blueprint $table): void {
+            $table->dropForeign(['knowledge_shelf_id']);
+            $table->dropForeign(['knowledge_book_id']);
+            $table->dropForeign(['knowledge_chapter_id']);
+        });
+
         Schema::dropIfExists('knowledge_chapters');
     }
 };

--- a/database/migrations/2026_05_16_134800_create_invite_tokens_table.php
+++ b/database/migrations/2026_05_16_134800_create_invite_tokens_table.php
@@ -3,7 +3,6 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use App\Models\Core\User;
 
 return new class extends Migration
 {
@@ -18,7 +17,7 @@ return new class extends Migration
     {
         Schema::create('invite_tokens', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->constrained((new User())->getTable())->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained('user_management')->cascadeOnDelete();
             $table->string('token', 64)->unique();
             $table->timestamp('expires_at');
             $table->timestamp('used_at')->nullable();

--- a/database/migrations/2026_05_16_140000_create_notifications_system.php
+++ b/database/migrations/2026_05_16_140000_create_notifications_system.php
@@ -3,7 +3,6 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use App\Models\Core\User;
 
 return new class extends Migration
 {
@@ -24,13 +23,13 @@ return new class extends Migration
             $table->timestamp('read_at')->nullable();
             $table->nullableTimestamps();
 
-            $table->index('notifiable_type', 'notifiable_id', 'read_at');
+            $table->index(['notifiable_type', 'notifiable_id', 'read_at'], 'notifications_notifiable_read_index');
         });
 
         // Per-user notification channel preferences
         Schema::create('notification_settings', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->constrained((new User())->getTable())->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained('user_management')->cascadeOnDelete();
             $table->string('notification_type'); // e.g. 'ticket_assigned', 'ticket_updated', 'asset_alert'
             $table->boolean('mail_enabled')->default(true);
             $table->boolean('database_enabled')->default(true);

--- a/database/migrations/2026_05_18_090000_create_calendar_tables.php
+++ b/database/migrations/2026_05_18_090000_create_calendar_tables.php
@@ -12,7 +12,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        $userTable = (new \App\Models\Core\User())->getTable();
+        $userTable = 'user_management';
 
         if (! Schema::hasTable('calendars')) {
             Schema::create('calendars', function (Blueprint $table) {

--- a/database/migrations/2026_05_18_100000_create_user_preferences_table.php
+++ b/database/migrations/2026_05_18_100000_create_user_preferences_table.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Models\Core\User;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -15,7 +14,7 @@ return new class extends Migration
 
         Schema::create('user_preferences', function (Blueprint $table) {
             $table->id();
-            $table->foreignIdFor(User::class)->unique()->constrained((new User())->getTable())->cascadeOnDelete();
+            $table->foreignId('user_id')->unique()->constrained('user_management')->cascadeOnDelete();
             $table->string('timezone')->default('Europe/Oslo');
             $table->string('default_calendar_view')->default('week');
             $table->time('workday_start')->default('08:00:00');

--- a/database/migrations/2026_05_18_110000_create_nextcloud_tables.php
+++ b/database/migrations/2026_05_18_110000_create_nextcloud_tables.php
@@ -54,7 +54,7 @@ return new class extends Migration
             Schema::create('nextcloud_user_credentials', function (Blueprint $table) {
                 $table->id();
                 $table->foreignId('connection_id')->constrained('nextcloud_connections')->cascadeOnDelete();
-                $table->foreignIdFor(User::class)->constrained((new User())->getTable())->cascadeOnDelete();
+                $table->foreignIdFor(User::class)->constrained('user_management')->cascadeOnDelete();
                 $table->string('remote_username');
                 $table->text('app_password')->nullable();
                 $table->boolean('is_active')->default(true);
@@ -92,7 +92,7 @@ return new class extends Migration
                 $table->id();
                 $table->foreignId('connection_id')->constrained('nextcloud_connections')->cascadeOnDelete();
                 $table->foreignId('calendar_id')->nullable()->constrained('calendars')->nullOnDelete();
-                $table->foreignIdFor(User::class)->nullable()->constrained((new User())->getTable())->nullOnDelete();
+                $table->foreignIdFor(User::class)->nullable()->constrained('user_management')->nullOnDelete();
                 $table->string('remote_calendar_id');
                 $table->string('remote_display_name')->nullable();
                 $table->string('sync_direction')->default('two_way');
@@ -110,7 +110,7 @@ return new class extends Migration
             Schema::create('nextcloud_user_mappings', function (Blueprint $table) {
                 $table->id();
                 $table->foreignId('connection_id')->constrained('nextcloud_connections')->cascadeOnDelete();
-                $table->foreignIdFor(User::class)->nullable()->constrained((new User())->getTable())->nullOnDelete();
+                $table->foreignIdFor(User::class)->nullable()->constrained('user_management')->nullOnDelete();
                 $table->string('remote_user_id');
                 $table->string('remote_username')->nullable();
                 $table->string('remote_email')->nullable();
@@ -152,7 +152,7 @@ return new class extends Migration
                 $table->string('operation');
                 $table->string('status')->default('queued');
                 $table->string('credential_source')->nullable();
-                $table->foreignIdFor(User::class)->nullable()->constrained((new User())->getTable())->nullOnDelete();
+                $table->foreignIdFor(User::class)->nullable()->constrained('user_management')->nullOnDelete();
                 $table->unsignedInteger('records_seen')->default(0);
                 $table->unsignedInteger('records_changed')->default(0);
                 $table->unsignedInteger('records_failed')->default(0);
@@ -179,8 +179,8 @@ return new class extends Migration
                 $table->json('local_snapshot')->nullable();
                 $table->json('remote_snapshot')->nullable();
                 $table->text('message')->nullable();
-                $table->foreignIdFor(User::class, 'assigned_user_id')->nullable()->constrained((new User())->getTable())->nullOnDelete();
-                $table->foreignIdFor(User::class, 'resolved_by')->nullable()->constrained((new User())->getTable())->nullOnDelete();
+                $table->foreignIdFor(User::class, 'assigned_user_id')->nullable()->constrained('user_management')->nullOnDelete();
+                $table->foreignIdFor(User::class, 'resolved_by')->nullable()->constrained('user_management')->nullOnDelete();
                 $table->timestamp('resolved_at')->nullable();
                 $table->timestamps();
 

--- a/database/migrations/2026_05_20_200000_create_sales_opportunity_tables.php
+++ b/database/migrations/2026_05_20_200000_create_sales_opportunity_tables.php
@@ -20,7 +20,7 @@ return new class extends Migration
             $table->string('opportunity_key')->unique();
             $table->foreignId('client_id')->constrained('clients')->cascadeOnDelete();
             $table->foreignId('primary_contact_id')->nullable()->constrained('client_users')->nullOnDelete();
-            $table->foreignId('owner_id')->nullable()->constrained(env('AUTH_USER_TABLE', 'users'))->nullOnDelete();
+            $table->foreignId('owner_id')->nullable()->constrained('user_management')->nullOnDelete();
             $table->string('title');
             $table->string('type')->default('service_agreement');
             $table->string('status')->default('new_lead')->index();
@@ -46,8 +46,8 @@ return new class extends Migration
             $table->timestamp('lost_at')->nullable();
             $table->text('lost_reason')->nullable();
             $table->json('metadata')->nullable();
-            $table->foreignId('created_by')->nullable()->constrained(env('AUTH_USER_TABLE', 'users'))->nullOnDelete();
-            $table->foreignId('updated_by')->nullable()->constrained(env('AUTH_USER_TABLE', 'users'))->nullOnDelete();
+            $table->foreignId('created_by')->nullable()->constrained('user_management')->nullOnDelete();
+            $table->foreignId('updated_by')->nullable()->constrained('user_management')->nullOnDelete();
             $table->timestamps();
             $table->softDeletes();
 
@@ -71,7 +71,7 @@ return new class extends Migration
         Schema::create('sales_activities', function (Blueprint $table): void {
             $table->id();
             $table->foreignId('opportunity_id')->constrained('sales_opportunities')->cascadeOnDelete();
-            $table->foreignId('actor_id')->nullable()->constrained(env('AUTH_USER_TABLE', 'users'))->nullOnDelete();
+            $table->foreignId('actor_id')->nullable()->constrained('user_management')->nullOnDelete();
             $table->string('type')->default('journal');
             $table->string('direction')->nullable();
             $table->string('subject')->nullable();
@@ -124,8 +124,8 @@ return new class extends Migration
             $table->string('accepted_ip')->nullable();
             $table->text('accepted_ua')->nullable();
             $table->timestamp('rejected_at')->nullable();
-            $table->foreignId('created_by')->nullable()->constrained(env('AUTH_USER_TABLE', 'users'))->nullOnDelete();
-            $table->foreignId('updated_by')->nullable()->constrained(env('AUTH_USER_TABLE', 'users'))->nullOnDelete();
+            $table->foreignId('created_by')->nullable()->constrained('user_management')->nullOnDelete();
+            $table->foreignId('updated_by')->nullable()->constrained('user_management')->nullOnDelete();
             $table->timestamps();
 
             $table->unique(['quote_id', 'version_number']);

--- a/database/seeders/LegalTermsSeeder.php
+++ b/database/seeders/LegalTermsSeeder.php
@@ -16,8 +16,8 @@ class LegalTermsSeeder extends Seeder
         terms::updateOrCreate(
             ['name' => 'General Terms of Service'],
             [
-                'term' => "1. Acceptance of Terms\nBy accessing and using our services, you agree to be bound by these General Terms of Service.\n\n2. Service Description\nWe provide IT professional services, including but not limited to support, maintenance, and consulting.\n\n3. User Obligations\nYou agree to provide accurate information and maintain the security of your account.\n\n4. Limitation of Liability\nOur liability is limited to the maximum extent permitted by law. We are not liable for indirect or consequential damages.",
-                'legal' => "This document constitutes a legally binding agreement between the Client and the Provider. Governed by the laws of Norway."
+                'type' => 'terms',
+                'content' => "1. Acceptance of Terms\nBy accessing and using our services, you agree to be bound by these General Terms of Service.\n\n2. Service Description\nWe provide IT professional services, including but not limited to support, maintenance, and consulting.\n\n3. User Obligations\nYou agree to provide accurate information and maintain the security of your account.\n\n4. Limitation of Liability\nOur liability is limited to the maximum extent permitted by law. We are not liable for indirect or consequential damages.\n\nLegal basis\nThis document constitutes a legally binding agreement between the Client and the Provider. Governed by the laws of Norway."
             ]
         );
 
@@ -25,8 +25,8 @@ class LegalTermsSeeder extends Seeder
         terms::updateOrCreate(
             ['name' => 'Data Processing Agreement (DPA)'],
             [
-                'term' => "1. Purpose of Processing\nWe process personal data solely for the purpose of providing the agreed services.\n\n2. Security Measures\nWe implement appropriate technical and organizational measures to ensure a level of security appropriate to the risk.\n\n3. Sub-processors\nA list of current sub-processors is available upon request.\n\n4. Data Subject Rights\nWe will assist the Client in fulfilling their obligations to respond to requests from data subjects.",
-                'legal' => "Compliant with GDPR (General Data Protection Regulation). All data remains within the EEA unless otherwise specified."
+                'type' => 'dpa',
+                'content' => "1. Purpose of Processing\nWe process personal data solely for the purpose of providing the agreed services.\n\n2. Security Measures\nWe implement appropriate technical and organizational measures to ensure a level of security appropriate to the risk.\n\n3. Sub-processors\nA list of current sub-processors is available upon request.\n\n4. Data Subject Rights\nWe will assist the Client in fulfilling their obligations to respond to requests from data subjects.\n\nLegal basis\nCompliant with GDPR (General Data Protection Regulation). All data remains within the EEA unless otherwise specified."
             ]
         );
 
@@ -34,8 +34,8 @@ class LegalTermsSeeder extends Seeder
         terms::updateOrCreate(
             ['name' => 'Acceptable Use Policy'],
             [
-                'term' => "1. Prohibited Activities\nYou may not use our services for any illegal activities, including but not limited to unauthorized access, distribution of malware, or harassment.\n\n2. Resource Usage\nUsers must not engage in activities that degrade the performance or security of our systems.",
-                'legal' => "Violations of this policy may result in immediate suspension or termination of services."
+                'type' => 'legal',
+                'content' => "1. Prohibited Activities\nYou may not use our services for any illegal activities, including but not limited to unauthorized access, distribution of malware, or harassment.\n\n2. Resource Usage\nUsers must not engage in activities that degrade the performance or security of our systems.\n\nLegal basis\nViolations of this policy may result in immediate suspension or termination of services."
             ]
         );
     }


### PR DESCRIPTION
- Replaced scattered user table references with a consistent `user_management` table reference in migrations and model logic.
- Improved schema clarity with explicit indexing and relationships across tables for better maintainability.