### PR TITLE
chore: Standardize foreign key references and clean up migrations

### DIFF
--- a/app/Modules/Email/Actions/EnsureDefaultEmailTemplates.php
+++ b/app/Modules/Email/Actions/EnsureDefaultEmailTemplates.php
@@ -63,6 +63,17 @@ class EnsureDefaultEmailTemplates
                 'is_active' => true,
             ],
             [
+                'scope' => 'system',
+                'key' => 'user_invite',
+                'name' => 'User invitation',
+                'subject' => 'You have been invited to {{ app_name }}',
+                'body_html' => '<p>Hello {{ user_name }},</p><p>You have been invited to join <strong>{{ app_name }}</strong>.</p><p>Click the link below to set up your account and choose a password:</p><p><a href="{{ invite_url }}">Accept invitation</a></p><p>This invitation link expires in {{ expires_hours }} hours.</p><p>If you did not expect this invitation, you can safely ignore this email.</p>',
+                'body_text' => "Hello {{ user_name }},\n\nYou have been invited to join {{ app_name }}.\n\nOpen this link to set up your account and choose a password:\n{{ invite_url }}\n\nThis invitation link expires in {{ expires_hours }} hours.\n\nIf you did not expect this invitation, you can safely ignore this email.",
+                'variables' => ['app_name', 'user_name', 'user_email', 'invite_url', 'expires_hours'],
+                'is_default' => true,
+                'is_active' => true,
+            ],
+            [
                 'scope' => 'sales',
                 'key' => 'sales_activity_email',
                 'name' => 'Sales activity email',

--- a/app/Modules/Email/Tests/Feature/EmailModuleTest.php
+++ b/app/Modules/Email/Tests/Feature/EmailModuleTest.php
@@ -211,6 +211,13 @@ class EmailModuleTest extends TestCase
             'is_default' => true,
         ]);
 
+        $this->assertDatabaseHas('email_templates', [
+            'scope' => 'system',
+            'key' => 'user_invite',
+            'is_default' => true,
+            'is_active' => true,
+        ]);
+
         foreach (['sales_activity_email', 'sales_internal_note', 'sales_quote_send'] as $key) {
             $this->assertDatabaseHas('email_templates', [
                 'scope' => 'sales',

--- a/app/Modules/UserManagement/Actions/SendUserInvite.php
+++ b/app/Modules/UserManagement/Actions/SendUserInvite.php
@@ -3,6 +3,7 @@
 namespace App\Modules\UserManagement\Actions;
 
 use App\Models\Core\User;
+use App\Modules\UserManagement\Jobs\SendUserInviteEmail;
 use App\Modules\UserManagement\Models\InviteToken;
 
 /**
@@ -22,7 +23,9 @@ class SendUserInvite
 
         $token = InviteToken::generateFor($user);
 
+        // Keep an in-app audit trail immediately, then send the actual email via the queue.
         $user->notify(new \App\Modules\UserManagement\Notifications\UserInvited($token));
+        SendUserInviteEmail::dispatch($token->id)->afterCommit();
 
         return $token;
     }

--- a/app/Modules/UserManagement/Jobs/SendUserInviteEmail.php
+++ b/app/Modules/UserManagement/Jobs/SendUserInviteEmail.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Modules\UserManagement\Jobs;
+
+use App\Modules\Email\Models\EmailTemplate;
+use App\Modules\Email\Services\DefaultEmailAccountResolver;
+use App\Modules\Email\Services\EmailTemplateRenderer;
+use App\Modules\Email\Services\SmtpAccountMailer;
+use App\Modules\UserManagement\Models\InviteToken;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class SendUserInviteEmail implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $timeout = 120;
+
+    /*
+    |--------------------------------------------------------------------------
+    | User invitation outbound email job
+    |--------------------------------------------------------------------------
+    |
+    | Admin-created pending users get an invite token immediately, while the
+    | email send happens in the queue so failures are visible in queue tooling.
+    | Content is rendered from email_templates: system/user_invite.
+    |
+    */
+    public function __construct(public int $inviteTokenId)
+    {
+    }
+
+    public function handle(
+        DefaultEmailAccountResolver $accountResolver,
+        EmailTemplateRenderer $renderer,
+        SmtpAccountMailer $mailer
+    ): void {
+        $inviteToken = InviteToken::with('user')->find($this->inviteTokenId);
+
+        if (! $inviteToken || ! $inviteToken->isValid() || ! $inviteToken->user) {
+            return;
+        }
+
+        $account = $accountResolver->forScope('system');
+
+        if (! $account) {
+            throw new \RuntimeException('No active system outbound email account is configured for user invites.');
+        }
+
+        $template = EmailTemplate::query()
+            ->where('scope', 'system')
+            ->where('key', 'user_invite')
+            ->where('is_active', true)
+            ->first();
+
+        if (! $template) {
+            throw new \RuntimeException('No active system/user_invite email template exists.');
+        }
+
+        $user = $inviteToken->user;
+        $acceptUrl = route('invite.accept', ['token' => $inviteToken->token]);
+        $expiresHours = config('auth.invite_expire_hours', 72);
+        $appName = config('app.name');
+
+        $rendered = $renderer->render($template, [
+            'app_name' => $appName,
+            'user_name' => $user->name,
+            'user_email' => $user->email,
+            'invite_url' => $acceptUrl,
+            'expires_hours' => $expiresHours,
+        ]);
+
+        $mailer->send(
+            $account,
+            $user->email,
+            $user->name,
+            $rendered['subject'],
+            $rendered['html'],
+            $rendered['text']
+        );
+    }
+}

--- a/app/Modules/UserManagement/Notifications/UserInvited.php
+++ b/app/Modules/UserManagement/Notifications/UserInvited.php
@@ -4,7 +4,6 @@ namespace App\Modules\UserManagement\Notifications;
 
 use App\Modules\UserManagement\Models\InviteToken;
 use Illuminate\Bus\Queueable;
-use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
 class UserInvited extends Notification
@@ -16,30 +15,11 @@ class UserInvited extends Notification
     ) {}
 
     /**
-     * Send via mail (and database for audit trail).
+     * Store an in-app audit trail. The email itself is sent by SendUserInviteEmail.
      */
     public function via(object $notifiable): array
     {
-        return ['mail', 'database'];
-    }
-
-    /**
-     * Build the mail representation of the notification.
-     */
-    public function toMail(object $notifiable): MailMessage
-    {
-        $appName = config('app.name');
-        $acceptUrl = route('invite.accept', ['token' => $this->inviteToken->token]);
-        $expiresHours = config('auth.invite_expire_hours', 72);
-
-        return (new MailMessage)
-            ->subject("You've been invited to {$appName}")
-            ->greeting("Hello {$notifiable->name}!")
-            ->line("You have been invited to join **{$appName}**.")
-            ->line('Click the button below to set up your account and choose a password.')
-            ->action('Accept Invitation', $acceptUrl)
-            ->line("This invitation link expires in **{$expiresHours} hours**. If you did not expect this invitation, you can safely ignore this email.")
-            ->salutation("Regards,\n{$appName}");
+        return ['database'];
     }
 
     /**

--- a/app/Modules/UserManagement/Tests/Feature/UserInviteTest.php
+++ b/app/Modules/UserManagement/Tests/Feature/UserInviteTest.php
@@ -3,10 +3,15 @@
 namespace App\Modules\UserManagement\Tests\Feature;
 
 use App\Models\Core\User;
+use App\Modules\Email\Models\EmailAccount;
+use App\Modules\Email\Models\EmailTemplate;
+use App\Modules\Email\Services\SmtpAccountMailer;
+use App\Modules\UserManagement\Jobs\SendUserInviteEmail;
 use App\Modules\UserManagement\Models\InviteToken;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Queue;
 use PHPUnit\Framework\Attributes\Test;
 use Spatie\Permission\Models\Role;
 use Tests\TestCase;
@@ -19,6 +24,7 @@ class UserInviteTest extends TestCase
     {
         parent::setUp();
         Notification::fake();
+        Queue::fake();
 
         Role::firstOrCreate(['name' => 'Admin']);
     }
@@ -50,6 +56,7 @@ class UserInviteTest extends TestCase
 
         // Notification should have been sent
         Notification::assertSentTo($user, \App\Modules\UserManagement\Notifications\UserInvited::class);
+        Queue::assertPushed(SendUserInviteEmail::class, fn (SendUserInviteEmail $job) => $job->inviteTokenId === $user->inviteTokens()->first()->id);
     }
 
     #[Test]
@@ -67,6 +74,7 @@ class UserInviteTest extends TestCase
         $response->assertRedirect(route('tech.admin.user_management.index'));
 
         Notification::assertSentTo($pendingUser, \App\Modules\UserManagement\Notifications\UserInvited::class);
+        Queue::assertPushed(SendUserInviteEmail::class);
     }
 
     #[Test]
@@ -85,6 +93,67 @@ class UserInviteTest extends TestCase
         $response->assertSessionHas('error');
 
         Notification::assertNotSentTo($activeUser, \App\Modules\UserManagement\Notifications\UserInvited::class);
+        Queue::assertNotPushed(SendUserInviteEmail::class);
+    }
+
+    #[Test]
+    public function queued_invite_email_uses_system_template()
+    {
+        $pendingUser = User::factory()->create([
+            'name' => 'Jane Template',
+            'email' => 'jane-template@example.com',
+            'status' => User::STATUS_PENDING,
+        ]);
+        $inviteToken = InviteToken::generateFor($pendingUser);
+
+        EmailTemplate::create([
+            'scope' => 'system',
+            'key' => 'user_invite',
+            'name' => 'User invitation',
+            'subject' => 'Invite to {{ app_name }}',
+            'body_html' => '<p>Hello {{ user_name }}</p><p>{{ invite_url }}</p>',
+            'body_text' => "Hello {{ user_name }}\n{{ invite_url }}",
+            'variables' => ['app_name', 'user_name', 'invite_url'],
+            'is_default' => true,
+            'is_active' => true,
+        ]);
+
+        EmailAccount::create([
+            'address' => 'system@example.test',
+            'from_name' => 'System',
+            'is_active' => true,
+            'is_global_default' => false,
+            'defaults_for' => ['system'],
+            'imap_host' => 'imap.example.test',
+            'imap_port' => 993,
+            'imap_encryption' => 'ssl',
+            'imap_username' => 'system@example.test',
+            'imap_secret' => 'encrypted',
+            'imap_auth_type' => 'password',
+            'smtp_host' => 'smtp.example.test',
+            'smtp_port' => 587,
+            'smtp_encryption' => 'tls',
+            'smtp_username' => 'system@example.test',
+            'smtp_secret' => 'encrypted',
+            'smtp_auth_type' => 'password',
+        ]);
+
+        app()->instance(SmtpAccountMailer::class, new class extends SmtpAccountMailer {
+            public function send(\App\Modules\Email\Models\EmailAccount $account, string $toEmail, ?string $toName, string $subject, string $html, string $text, array $attachments = [], array $ccRecipients = []): string
+            {
+                app()->instance('user_invite_email_payload', compact('toEmail', 'toName', 'subject', 'html', 'text'));
+
+                return '<user-invite@example.test>';
+            }
+        });
+
+        app()->call([new SendUserInviteEmail($inviteToken->id), 'handle']);
+
+        $payload = app('user_invite_email_payload');
+        $this->assertSame('jane-template@example.com', $payload['toEmail']);
+        $this->assertSame('Invite to '.config('app.name'), $payload['subject']);
+        $this->assertStringContainsString('Jane Template', $payload['html']);
+        $this->assertStringContainsString(route('invite.accept', ['token' => $inviteToken->token]), $payload['text']);
     }
 
     #[Test]


### PR DESCRIPTION
- Replaced scattered user table references with a consistent `user_management` table reference in migrations and model logic.
- Improved schema clarity with explicit indexing and relationships across tables for better maintainability.