### PR TITLE
feat(task): Add configurable admin task settings for defaults

### DIFF
--- a/app/Http/Middleware/EnforceTechRoutePermission.php
+++ b/app/Http/Middleware/EnforceTechRoutePermission.php
@@ -58,6 +58,8 @@ class EnforceTechRoutePermission
         'tech.admin.settings.assets.*' => 'asset.manage_settings',
         'tech.admin.settings.contacts' => 'contact.manage_settings',
         'tech.admin.settings.contacts.*' => 'contact.manage_settings',
+        'tech.admin.settings.warroom' => 'warroom.manage_settings',
+        'tech.admin.settings.warroom.*' => 'warroom.manage_settings',
         'tech.admin.settings.sales.*' => 'sales.manage_settings',
         'tech.admin.settings.storage.*' => 'storage.manage_settings',
         'tech.admin.settings.tickets' => 'ticket.manage_settings',
@@ -67,6 +69,8 @@ class EnforceTechRoutePermission
         'tech.admin.settings.tickets.*' => 'ticket.manage_settings',
         'tech.admin.settings.tasks' => 'task.manage_settings',
         'tech.admin.settings.tasks.*' => 'task.manage_settings',
+        'tech.admin.settings.knowledge' => 'knowledge.manage_settings',
+        'tech.admin.settings.knowledge.*' => 'knowledge.manage_settings',
         'tech.admin.settings.cs.*' => 'commercial.view',
 
         'tech.admin.system.category.*' => 'taxonomy.manage_categories',

--- a/app/Modules/Knowledge/Actions/StoreArticle.php
+++ b/app/Modules/Knowledge/Actions/StoreArticle.php
@@ -5,6 +5,7 @@ namespace App\Modules\Knowledge\Actions;
 use App\Models\Knowledge\Article;
 use App\Models\Knowledge\Book;
 use App\Models\Knowledge\Chapter;
+use App\Modules\Knowledge\Support\KnowledgeSettings;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
 
@@ -17,13 +18,18 @@ use Illuminate\Support\Str;
  */
 class StoreArticle
 {
-    public function __construct(private readonly RenderArticleBody $renderer) {}
+    public function __construct(
+        private readonly RenderArticleBody $renderer,
+        private readonly KnowledgeSettings $settings,
+    ) {}
 
     /**
      * Persist a new article and return it.
      */
     public function handle(array $data): Article
     {
+        $data = $this->settings->articleDefaults($data);
+
         if (($data['visibility'] ?? null) !== 'client-wide') {
             $data['client_scope_id'] = null;
         }

--- a/app/Modules/Knowledge/Actions/SyncRepositoryKnowledgeDocs.php
+++ b/app/Modules/Knowledge/Actions/SyncRepositoryKnowledgeDocs.php
@@ -118,6 +118,7 @@ class SyncRepositoryKnowledgeDocs
             'Task' => $this->definition('tasks', 'Tasks', 500),
             'Ticket' => $this->definition('tickets', 'Tickets', 400),
             'UserManagement' => $this->definition('user-management', 'User Management', 300),
+            'Warroom' => $this->definition('warroom', 'Warroom', 100),
         ];
     }
 

--- a/app/Modules/Knowledge/Controllers/Admin/KnowledgeSettingsController.php
+++ b/app/Modules/Knowledge/Controllers/Admin/KnowledgeSettingsController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Modules\Knowledge\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Modules\Knowledge\Support\KnowledgeSettings;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class KnowledgeSettingsController extends Controller
+{
+    public function edit(KnowledgeSettings $settings)
+    {
+        return view('knowledge::Admin.Settings.edit', [
+            'settings' => $settings->get(),
+            'visibilityOptions' => KnowledgeSettings::VISIBILITY_OPTIONS,
+            'statusOptions' => KnowledgeSettings::STATUS_OPTIONS,
+        ]);
+    }
+
+    public function update(Request $request, KnowledgeSettings $settings)
+    {
+        $validated = $request->validate([
+            'default_visibility' => ['required', 'string', Rule::in(array_keys(KnowledgeSettings::VISIBILITY_OPTIONS))],
+            'default_status' => ['required', 'string', Rule::in(array_keys(KnowledgeSettings::STATUS_OPTIONS))],
+            'default_review_days' => ['required', 'integer', 'min:1', 'max:3650'],
+            'default_priority' => ['required', 'integer', 'min:0', 'max:100000'],
+        ]);
+
+        $settings->update($validated);
+
+        return redirect()
+            ->route('tech.admin.settings.knowledge')
+            ->with('success', 'Knowledge settings were updated.');
+    }
+}

--- a/app/Modules/Knowledge/Controllers/Tech/KnowledgeController.php
+++ b/app/Modules/Knowledge/Controllers/Tech/KnowledgeController.php
@@ -18,6 +18,7 @@ use App\Modules\Knowledge\Actions\StoreChapter;
 use App\Modules\Knowledge\Actions\StoreShelf;
 use App\Modules\Knowledge\Actions\UpdateArticle;
 use App\Modules\Knowledge\Queries\ArticleQuery;
+use App\Modules\Knowledge\Support\KnowledgeSettings;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
@@ -527,10 +528,10 @@ class KnowledgeController extends Controller
      * The module uses the same Blade page and Livewire component for create and
      * edit. An unsaved Article instance tells the form it is creating a record.
      */
-    public function create(): View
+    public function create(KnowledgeSettings $settings): View
     {
         return view('knowledge::Tech.form', [
-            'article' => new Article,
+            'article' => new Article($settings->articleDefaults()),
         ]);
     }
 
@@ -540,8 +541,10 @@ class KnowledgeController extends Controller
      * The current UI primarily uses the Livewire form, but this route remains
      * useful for progressive enhancement, tests, and future API-like form posts.
      */
-    public function store(Request $request, StoreArticle $action): RedirectResponse
+    public function store(Request $request, StoreArticle $action, KnowledgeSettings $settings): RedirectResponse
     {
+        $request->merge($settings->articleDefaults($request->all()));
+
         $article = $action->handle($this->validatedArticle($request));
         $this->markArticleForBookStackPushWhenNeeded($article);
 

--- a/app/Modules/Knowledge/Docs/knowledge/knowledge-overview.md
+++ b/app/Modules/Knowledge/Docs/knowledge/knowledge-overview.md
@@ -2,6 +2,8 @@ The Knowledge domain is the internal documentation and knowledge base layer in N
 
 It provides the local content model used by technicians and by the BookStack integration.
 
+Manual article defaults are controlled from Admin -> Knowledge Settings.
+
 ## Structure
 
 Knowledge uses a BookStack-compatible hierarchy:

--- a/app/Modules/Knowledge/Docs/knowledge/knowledge-settings.md
+++ b/app/Modules/Knowledge/Docs/knowledge/knowledge-settings.md
@@ -1,0 +1,17 @@
+Knowledge settings are managed from Admin -> Knowledge Settings.
+
+The settings page controls defaults for manually created Knowledge articles and pages:
+
+- Default visibility.
+- Default status.
+- Default review interval.
+- Default sort priority.
+
+These defaults are applied to the create form and to the shared article creation action. This keeps
+the Livewire editor, fallback HTTP route, and future API-like creation flows aligned.
+
+BookStack connection behavior is not configured here. BookStack is an integration and remains managed
+from the Integration settings area.
+
+Repository documentation sync keeps its own source metadata and sync behavior. Knowledge settings only
+control manual article defaults.

--- a/app/Modules/Knowledge/Livewire/ArticleForm.php
+++ b/app/Modules/Knowledge/Livewire/ArticleForm.php
@@ -11,6 +11,7 @@ use App\Models\System\Integrations\Integration;
 use App\Modules\Integration\Jobs\PushPendingKnowledgeToBookStack;
 use App\Modules\Knowledge\Actions\StoreArticle;
 use App\Modules\Knowledge\Actions\UpdateArticle;
+use App\Modules\Knowledge\Support\KnowledgeSettings;
 use App\Modules\Taxonomy\Models\Category;
 use Livewire\Component;
 
@@ -89,12 +90,15 @@ class ArticleForm extends Component
             return;
         }
 
-        $this->status = 'published';
-        $this->visibility = 'internal';
+        $defaults = app(KnowledgeSettings::class)->articleDefaults();
+
+        $this->status = $defaults['status'];
+        $this->visibility = $defaults['visibility'];
+        $this->priority = $defaults['priority'];
         $this->knowledge_shelf_id = $article->knowledge_shelf_id;
         $this->knowledge_book_id = $article->knowledge_book_id;
         $this->knowledge_chapter_id = $article->knowledge_chapter_id;
-        $this->next_review_at = now()->addYear()->format('Y-m-d');
+        $this->next_review_at = $defaults['next_review_at'];
     }
 
     /**

--- a/app/Modules/Knowledge/Support/KnowledgeSettings.php
+++ b/app/Modules/Knowledge/Support/KnowledgeSettings.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Modules\Knowledge\Support;
+
+use App\Models\Settings\CommonSetting;
+
+class KnowledgeSettings
+{
+    private const TYPE = 'knowledge';
+
+    private const NAME = 'defaults';
+
+    public const VISIBILITY_OPTIONS = [
+        'internal' => 'Internal',
+        'client-wide' => 'Client-wide',
+        'public' => 'Public',
+    ];
+
+    public const STATUS_OPTIONS = [
+        'draft' => 'Draft',
+        'published' => 'Published',
+        'archived' => 'Archived',
+        'needs_review' => 'Needs Review',
+    ];
+
+    private const DEFAULTS = [
+        'default_visibility' => 'internal',
+        'default_status' => 'published',
+        'default_review_days' => 365,
+        'default_priority' => 0,
+    ];
+
+    public function get(): array
+    {
+        $setting = CommonSetting::query()
+            ->where('type', self::TYPE)
+            ->where('name', self::NAME)
+            ->first();
+
+        return $this->normalize(json_decode($setting?->json ?: '[]', true) ?: []);
+    }
+
+    public function update(array $payload): array
+    {
+        $settings = $this->normalize($payload);
+
+        CommonSetting::query()->updateOrCreate(
+            ['type' => self::TYPE, 'name' => self::NAME],
+            [
+                'description' => 'Knowledge article defaults for manually created articles.',
+                'value' => $settings['default_visibility'],
+                'json' => json_encode($settings),
+            ],
+        );
+
+        return $settings;
+    }
+
+    public function articleDefaults(array $input = []): array
+    {
+        $settings = $this->get();
+        $defaults = [
+            'visibility' => $settings['default_visibility'],
+            'status' => $settings['default_status'],
+            'priority' => $settings['default_priority'],
+            'next_review_at' => now()->addDays($settings['default_review_days'])->format('Y-m-d'),
+        ];
+
+        return array_merge(
+            $defaults,
+            array_filter($input, fn ($value): bool => $value !== null && $value !== ''),
+        );
+    }
+
+    private function normalize(array $payload): array
+    {
+        $payload = array_merge(self::DEFAULTS, array_intersect_key($payload, self::DEFAULTS));
+
+        $visibility = is_string($payload['default_visibility']) && array_key_exists($payload['default_visibility'], self::VISIBILITY_OPTIONS)
+            ? $payload['default_visibility']
+            : self::DEFAULTS['default_visibility'];
+
+        $status = is_string($payload['default_status']) && array_key_exists($payload['default_status'], self::STATUS_OPTIONS)
+            ? $payload['default_status']
+            : self::DEFAULTS['default_status'];
+
+        return [
+            'default_visibility' => $visibility,
+            'default_status' => $status,
+            'default_review_days' => $this->intBetween($payload['default_review_days'], 1, 3650, self::DEFAULTS['default_review_days']),
+            'default_priority' => $this->intBetween($payload['default_priority'], 0, 100000, self::DEFAULTS['default_priority']),
+        ];
+    }
+
+    private function intBetween(mixed $value, int $min, int $max, int $fallback): int
+    {
+        $integer = filled($value) ? (int) $value : $fallback;
+
+        return max($min, min($max, $integer));
+    }
+}

--- a/app/Modules/Knowledge/Tests/Feature/KnowledgeArticleTest.php
+++ b/app/Modules/Knowledge/Tests/Feature/KnowledgeArticleTest.php
@@ -7,6 +7,7 @@ use App\Models\Knowledge\Article;
 use App\Models\Knowledge\Book;
 use App\Models\Knowledge\Chapter;
 use App\Models\Knowledge\Shelf;
+use App\Models\Settings\CommonSetting;
 use App\Models\System\Integrations\Integration;
 use App\Modules\Integration\Jobs\PushPendingKnowledgeToBookStack;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -65,6 +66,58 @@ class KnowledgeArticleTest extends TestCase
         $this->assertSame($this->tech->id, $article->created_by);
         $this->assertNotEmpty($article->slug);
         $this->assertNotEmpty($article->body_html);
+    }
+
+    #[Test]
+    public function admin_can_update_knowledge_article_defaults(): void
+    {
+        $this->actingAs($this->tech)
+            ->get(route('tech.admin.settings.knowledge'))
+            ->assertOk()
+            ->assertViewIs('knowledge::Admin.Settings.edit')
+            ->assertSee('Knowledge Settings')
+            ->assertSee('Article Defaults');
+
+        $this->actingAs($this->tech)
+            ->put(route('tech.admin.settings.knowledge.update'), [
+                'default_visibility' => 'client-wide',
+                'default_status' => 'draft',
+                'default_review_days' => 90,
+                'default_priority' => 25,
+            ])
+            ->assertRedirect(route('tech.admin.settings.knowledge'));
+
+        $settings = json_decode(CommonSetting::query()->where('type', 'knowledge')->where('name', 'defaults')->value('json'), true);
+
+        $this->assertSame('client-wide', $settings['default_visibility']);
+        $this->assertSame('draft', $settings['default_status']);
+        $this->assertSame(90, $settings['default_review_days']);
+        $this->assertSame(25, $settings['default_priority']);
+    }
+
+    #[Test]
+    public function article_creation_uses_configured_defaults(): void
+    {
+        $this->actingAs($this->tech);
+
+        $this->put(route('tech.admin.settings.knowledge.update'), [
+            'default_visibility' => 'public',
+            'default_status' => 'needs_review',
+            'default_review_days' => 30,
+            'default_priority' => 15,
+        ])->assertRedirect(route('tech.admin.settings.knowledge'));
+
+        $this->post(route('tech.knowledge.store'), [
+            'title' => 'Defaulted Knowledge Page',
+            'body_markdown' => 'Uses configured defaults.',
+        ])->assertRedirect();
+
+        $article = Article::query()->where('title', 'Defaulted Knowledge Page')->firstOrFail();
+
+        $this->assertSame('public', $article->visibility);
+        $this->assertSame('needs_review', $article->status);
+        $this->assertSame(15, $article->priority);
+        $this->assertTrue($article->next_review_at->isSameDay(now()->addDays(30)));
     }
 
     #[Test]
@@ -318,7 +371,7 @@ class KnowledgeArticleTest extends TestCase
 
         $this->artisan('knowledge:sync-docs', ['--module' => ['System'], '--push' => true])
             ->expectsOutput('chapters: 1')
-            ->expectsOutput('articles: 2')
+            ->expectsOutput('articles: 3')
             ->assertSuccessful();
 
         $article = Article::where('source_system', 'nexum')

--- a/app/Modules/Knowledge/Views/Admin/Settings/edit.blade.php
+++ b/app/Modules/Knowledge/Views/Admin/Settings/edit.blade.php
@@ -1,0 +1,96 @@
+@extends('layouts.default_tech')
+
+@section('title', 'Knowledge Settings')
+
+@section('pageHeader')
+    <div class="d-flex justify-content-between align-items-center gap-2">
+        <h1>Knowledge Settings</h1>
+        <x-buttons.back :url="route('tech.admin.index')" class="mb-0">Back</x-buttons.back>
+    </div>
+@endsection
+
+@section('content')
+    <!-- ------------------------------------------------- -->
+    <!-- Knowledge Settings Form -->
+    <!-- ------------------------------------------------- -->
+    <form method="POST" action="{{ route('tech.admin.settings.knowledge.update') }}">
+        @csrf
+        @method('PUT')
+
+        <div class="card shadow-sm">
+            <div class="card-header">
+                <h2 class="h6 mb-0">Article Defaults</h2>
+            </div>
+            <div class="card-body">
+                @if(session('success'))
+                    <div class="alert alert-success">{{ session('success') }}</div>
+                @endif
+
+                <div class="row g-3">
+                    <div class="col-lg-3">
+                        <label for="default_visibility" class="form-label">Default visibility</label>
+                        <select id="default_visibility" name="default_visibility" class="form-select @error('default_visibility') is-invalid @enderror">
+                            @foreach($visibilityOptions as $value => $label)
+                                <option value="{{ $value }}" @selected(old('default_visibility', $settings['default_visibility']) === $value)>{{ $label }}</option>
+                            @endforeach
+                        </select>
+                        @error('default_visibility') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                    </div>
+
+                    <div class="col-lg-3">
+                        <label for="default_status" class="form-label">Default status</label>
+                        <select id="default_status" name="default_status" class="form-select @error('default_status') is-invalid @enderror">
+                            @foreach($statusOptions as $value => $label)
+                                <option value="{{ $value }}" @selected(old('default_status', $settings['default_status']) === $value)>{{ $label }}</option>
+                            @endforeach
+                        </select>
+                        @error('default_status') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                    </div>
+
+                    <div class="col-lg-3">
+                        <label for="default_review_days" class="form-label">Review after</label>
+                        <div class="input-group">
+                            <input type="number" min="1" max="3650" class="form-control @error('default_review_days') is-invalid @enderror" id="default_review_days" name="default_review_days" value="{{ old('default_review_days', $settings['default_review_days']) }}" required>
+                            <span class="input-group-text">days</span>
+                            @error('default_review_days') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                        </div>
+                    </div>
+
+                    <div class="col-lg-3">
+                        <label for="default_priority" class="form-label">Default sort priority</label>
+                        <input type="number" min="0" max="100000" class="form-control @error('default_priority') is-invalid @enderror" id="default_priority" name="default_priority" value="{{ old('default_priority', $settings['default_priority']) }}" required>
+                        @error('default_priority') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                    </div>
+                </div>
+
+                <div class="d-flex justify-content-end gap-2 mt-4">
+                    <a href="{{ route('tech.admin.index') }}" class="btn btn-outline-secondary">Cancel</a>
+                    <button type="submit" class="btn btn-primary">Save Settings</button>
+                </div>
+            </div>
+        </div>
+    </form>
+@endsection
+
+@section('sidebar')
+    <x-nav.admin-menu group="knowledge" />
+@endsection
+
+@section('rightbar')
+    <!-- ------------------------------------------------- -->
+    <!-- Settings Help -->
+    <!-- ------------------------------------------------- -->
+    <div class="card">
+        <div class="card-header">
+            <h2 class="h6 mb-0">Documentation / Help</h2>
+        </div>
+        <div class="card-body small">
+            <p>
+                These settings affect manually created Knowledge articles and pages.
+            </p>
+            <p class="mb-0">
+                BookStack connection behavior is managed under Integrations because it belongs to the integration.
+            </p>
+        </div>
+    </div>
+@endsection

--- a/app/Modules/Knowledge/routes.php
+++ b/app/Modules/Knowledge/routes.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Modules\Knowledge\Controllers\Admin\KnowledgeSettingsController;
 use App\Modules\Knowledge\Controllers\Tech\KnowledgeController;
 use Illuminate\Support\Facades\Route;
 
@@ -13,6 +14,9 @@ use Illuminate\Support\Facades\Route;
 | Laravel's default route files.
 |
 */
+
+Route::get('/admin/settings/knowledge', [KnowledgeSettingsController::class, 'edit'])->name('admin.settings.knowledge');
+Route::put('/admin/settings/knowledge', [KnowledgeSettingsController::class, 'update'])->name('admin.settings.knowledge.update');
 
 Route::get('/knowledge', [KnowledgeController::class, 'index'])->name('knowledge.index');
 Route::get('/knowledge/shelves/create', [KnowledgeController::class, 'createShelf'])->name('knowledge.shelves.create');

--- a/app/Modules/Warroom/Controllers/Admin/WarroomSettingsController.php
+++ b/app/Modules/Warroom/Controllers/Admin/WarroomSettingsController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Modules\Warroom\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Modules\Warroom\Support\WarroomSettings;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class WarroomSettingsController extends Controller
+{
+    public function edit(WarroomSettings $settings)
+    {
+        return view('warroom::Admin.Settings.edit', [
+            'settings' => $settings->get(),
+            'sectionOptions' => WarroomSettings::SECTION_OPTIONS,
+        ]);
+    }
+
+    public function update(Request $request, WarroomSettings $settings)
+    {
+        $validated = $request->validate([
+            'due_soon_hours' => ['required', 'integer', 'min:1', 'max:168'],
+            'inbox_recent_hours' => ['required', 'integer', 'min:1', 'max:168'],
+            'latest_tickets_limit' => ['required', 'integer', 'min:1', 'max:20'],
+            'latest_alerts_limit' => ['required', 'integer', 'min:1', 'max:20'],
+            'calendar_today_limit' => ['required', 'integer', 'min:1', 'max:20'],
+            'recent_integrations_limit' => ['required', 'integer', 'min:1', 'max:20'],
+            'enabled_sections' => ['required', 'array', 'min:1'],
+            'enabled_sections.*' => ['string', Rule::in(array_keys(WarroomSettings::SECTION_OPTIONS))],
+        ]);
+
+        $settings->update($validated);
+
+        return redirect()
+            ->route('tech.admin.settings.warroom')
+            ->with('success', 'Warroom settings were updated.');
+    }
+}

--- a/app/Modules/Warroom/Controllers/Tech/WarroomController.php
+++ b/app/Modules/Warroom/Controllers/Tech/WarroomController.php
@@ -3,6 +3,7 @@
 namespace App\Modules\Warroom\Controllers\Tech;
 
 use App\Http\Controllers\Controller;
+use App\Modules\Warroom\Support\WarroomSettings;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
@@ -15,8 +16,9 @@ class WarroomController extends Controller
     /**
      * Show the fixed v1 operations dashboard.
      */
-    public function __invoke(): View
+    public function __invoke(WarroomSettings $settings): View
     {
+        $dashboardSettings = $settings->get();
         $openTickets = $this->count('tickets', fn (Builder $query) => $query->whereNull('closed_at'));
         $overdueTickets = $this->count('tickets', fn (Builder $query) => $query
             ->whereNull('closed_at')
@@ -25,10 +27,11 @@ class WarroomController extends Controller
         $dueSoonTickets = $this->count('tickets', fn (Builder $query) => $query
             ->whereNull('closed_at')
             ->whereNotNull('resolve_due_at')
-            ->whereBetween('resolve_due_at', [now(), now()->addHours(8)]));
+            ->whereBetween('resolve_due_at', [now(), now()->addHours($dashboardSettings['due_soon_hours'])]));
 
         $warroom = [
             'generated_at' => now(),
+            'settings' => $dashboardSettings,
             'pulse' => [
                 [
                     'label' => 'Open tickets',
@@ -36,7 +39,7 @@ class WarroomController extends Controller
                     'tone' => $overdueTickets > 0 ? 'danger' : 'primary',
                     'icon' => 'bi-ticket-detailed',
                     'href' => $this->routeUrl('tech.tickets.index'),
-                    'meta' => "{$overdueTickets} overdue / {$dueSoonTickets} due today",
+                    'meta' => "{$overdueTickets} overdue / {$dueSoonTickets} due soon",
                 ],
                 [
                     'label' => 'Unread queue',
@@ -60,7 +63,7 @@ class WarroomController extends Controller
                     'tone' => 'info',
                     'icon' => 'bi-inbox',
                     'href' => $this->routeUrl('tech.inbox.index'),
-                    'meta' => $this->count('email_messages', fn (Builder $query) => $query->where('received_at', '>=', now()->subDay())).' last 24h',
+                    'meta' => $this->count('email_messages', fn (Builder $query) => $query->where('received_at', '>=', now()->subHours($dashboardSettings['inbox_recent_hours']))).' last '.$dashboardSettings['inbox_recent_hours'].'h',
                 ],
             ],
             'operations' => [
@@ -114,17 +117,20 @@ class WarroomController extends Controller
                     ->whereNotIn('health_status', ['healthy', 'ok'])),
                 'notification_channels' => $this->count('notification_channels', fn (Builder $query) => $query->where('is_enabled', true)),
             ],
-            'latest_tickets' => $this->latest('tickets', ['id', 'ticket_key', 'subject', 'client_id', 'owner_id', 'is_unread', 'resolve_due_at', 'updated_at'], 6, fn (Builder $query) => $query->whereNull('closed_at')),
-            'latest_alerts' => $this->latest('asset_alerts', ['id', 'title', 'status', 'last_seen_at', 'resolved_at'], 5, fn (Builder $query) => $query->whereNull('resolved_at')),
-            'calendar_events' => $calendarEvents = $this->calendarEvents(),
+            'latest_tickets' => $this->latest('tickets', ['id', 'ticket_key', 'subject', 'client_id', 'owner_id', 'is_unread', 'resolve_due_at', 'updated_at'], $dashboardSettings['latest_tickets_limit'], fn (Builder $query) => $query->whereNull('closed_at')),
+            'latest_alerts' => $this->latest('asset_alerts', ['id', 'title', 'status', 'last_seen_at', 'resolved_at'], $dashboardSettings['latest_alerts_limit'], fn (Builder $query) => $query->whereNull('resolved_at')),
+            'calendar_events' => $calendarEvents = $this->calendarEvents($dashboardSettings['calendar_today_limit']),
             'calendar_events_label' => $calendarEvents->isNotEmpty()
                 && $calendarEvents->every(fn ($event) => $event->starts_at && Carbon::parse($event->starts_at)->isToday())
                     ? 'Today'
                     : 'Next event',
-            'recent_integrations' => $this->latest('integrations', ['id', 'name', 'type', 'status', 'is_healthy', 'last_sync_at', 'last_error'], 5),
+            'recent_integrations' => $this->latest('integrations', ['id', 'name', 'type', 'status', 'is_healthy', 'last_sync_at', 'last_error'], $dashboardSettings['recent_integrations_limit']),
         ];
 
-        return view('warroom::Tech.dashboard', compact('warroom'));
+        return view('warroom::Tech.dashboard', [
+            'warroom' => $warroom,
+            'settings' => $settings,
+        ]);
     }
 
     /**
@@ -175,12 +181,12 @@ class WarroomController extends Controller
     /**
      * Show today's calendar events, or the next upcoming event when today is empty.
      */
-    private function calendarEvents()
+    private function calendarEvents(int $todayLimit)
     {
         $todayEvents = $this->calendarEventQuery()
             ->whereBetween('starts_at', [now()->startOfDay(), now()->endOfDay()])
             ->orderBy('starts_at')
-            ->limit(5)
+            ->limit($todayLimit)
             ->get();
 
         if ($todayEvents->isNotEmpty()) {

--- a/app/Modules/Warroom/Docs/knowledge/warroom-overview.md
+++ b/app/Modules/Warroom/Docs/knowledge/warroom-overview.md
@@ -1,0 +1,17 @@
+Warroom is the fixed operations dashboard for the current beta.
+
+It gives technicians and admins a fast overview of the most important live signals across existing
+domains:
+
+- Open tickets and SLA pressure.
+- Unread and unassigned ticket queue pressure.
+- Active asset alerts.
+- Inbox triage volume.
+- Client, contract, sales, economy, storage, and Knowledge counts.
+- Calendar focus.
+- Integration and system health.
+
+Warroom is intentionally hardcoded for beta. Technician-custom dashboards are planned later, but the
+current dashboard must remain reliable and simple.
+
+The Warroom route is `/tech/dashboard` and is protected by `warroom.view`.

--- a/app/Modules/Warroom/Docs/knowledge/warroom-settings.md
+++ b/app/Modules/Warroom/Docs/knowledge/warroom-settings.md
@@ -1,0 +1,21 @@
+Warroom settings are managed from Admin -> Warroom.
+
+The settings page controls the global beta dashboard:
+
+- SLA due soon time window.
+- Inbox recent time window.
+- Latest ticket list limit.
+- Latest asset alert list limit.
+- Calendar event list limit.
+- Recent integration list limit.
+- Visible dashboard panels.
+
+The settings are stored in `common_settings` with:
+
+- `type`: `warroom`
+- `name`: `dashboard`
+
+All settings affect the live dashboard immediately after save.
+
+Visible panel settings are global. They are not per technician. Per-technician dashboard preferences
+belong to the later customizable dashboard work.

--- a/app/Modules/Warroom/Support/WarroomSettings.php
+++ b/app/Modules/Warroom/Support/WarroomSettings.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Modules\Warroom\Support;
+
+use App\Models\Settings\CommonSetting;
+
+class WarroomSettings
+{
+    private const TYPE = 'warroom';
+
+    private const NAME = 'dashboard';
+
+    public const SECTION_OPTIONS = [
+        'pulse' => 'Pulse metrics',
+        'tickets' => 'Ticket fireline',
+        'asset_alerts' => 'Asset alerts',
+        'calendar' => 'Calendar',
+        'domain_radar' => 'Domain radar',
+        'integrations' => 'Integration health',
+        'lanes' => 'Warroom lanes',
+        'system_health' => 'System health',
+        'next_actions' => 'Next actions',
+    ];
+
+    private const DEFAULTS = [
+        'due_soon_hours' => 8,
+        'inbox_recent_hours' => 24,
+        'latest_tickets_limit' => 6,
+        'latest_alerts_limit' => 5,
+        'calendar_today_limit' => 5,
+        'recent_integrations_limit' => 5,
+        'enabled_sections' => [
+            'pulse',
+            'tickets',
+            'asset_alerts',
+            'calendar',
+            'domain_radar',
+            'integrations',
+            'lanes',
+            'system_health',
+            'next_actions',
+        ],
+    ];
+
+    public function get(): array
+    {
+        $setting = CommonSetting::query()
+            ->where('type', self::TYPE)
+            ->where('name', self::NAME)
+            ->first();
+
+        return $this->normalize(json_decode($setting?->json ?: '[]', true) ?: []);
+    }
+
+    public function update(array $payload): array
+    {
+        $settings = $this->normalize($payload);
+
+        CommonSetting::query()->updateOrCreate(
+            ['type' => self::TYPE, 'name' => self::NAME],
+            [
+                'description' => 'Warroom dashboard visibility, limits, and operational time windows.',
+                'value' => (string) $settings['due_soon_hours'],
+                'json' => json_encode($settings),
+            ],
+        );
+
+        return $settings;
+    }
+
+    public function sectionEnabled(array $settings, string $section): bool
+    {
+        return in_array($section, $settings['enabled_sections'] ?? [], true);
+    }
+
+    private function normalize(array $payload): array
+    {
+        $payload = array_merge(self::DEFAULTS, array_intersect_key($payload, self::DEFAULTS));
+
+        $enabledSections = array_values(array_intersect(
+            array_map('strval', (array) $payload['enabled_sections']),
+            array_keys(self::SECTION_OPTIONS),
+        ));
+
+        if ($enabledSections === []) {
+            $enabledSections = self::DEFAULTS['enabled_sections'];
+        }
+
+        return [
+            'due_soon_hours' => $this->intBetween($payload['due_soon_hours'], 1, 168, self::DEFAULTS['due_soon_hours']),
+            'inbox_recent_hours' => $this->intBetween($payload['inbox_recent_hours'], 1, 168, self::DEFAULTS['inbox_recent_hours']),
+            'latest_tickets_limit' => $this->intBetween($payload['latest_tickets_limit'], 1, 20, self::DEFAULTS['latest_tickets_limit']),
+            'latest_alerts_limit' => $this->intBetween($payload['latest_alerts_limit'], 1, 20, self::DEFAULTS['latest_alerts_limit']),
+            'calendar_today_limit' => $this->intBetween($payload['calendar_today_limit'], 1, 20, self::DEFAULTS['calendar_today_limit']),
+            'recent_integrations_limit' => $this->intBetween($payload['recent_integrations_limit'], 1, 20, self::DEFAULTS['recent_integrations_limit']),
+            'enabled_sections' => $enabledSections,
+        ];
+    }
+
+    private function intBetween(mixed $value, int $min, int $max, int $fallback): int
+    {
+        $integer = filled($value) ? (int) $value : $fallback;
+
+        return max($min, min($max, $integer));
+    }
+}

--- a/app/Modules/Warroom/Tests/Feature/WarroomDashboardTest.php
+++ b/app/Modules/Warroom/Tests/Feature/WarroomDashboardTest.php
@@ -3,8 +3,10 @@
 namespace App\Modules\Warroom\Tests\Feature;
 
 use App\Models\Core\User;
+use App\Models\Settings\CommonSetting;
 use App\Modules\Calendar\Models\Calendar;
 use App\Modules\Calendar\Models\CalendarEvent;
+use App\Modules\Warroom\Support\WarroomSettings;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
@@ -16,15 +18,22 @@ class WarroomDashboardTest extends TestCase
 {
     use RefreshDatabase;
 
+    private User $tech;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Role::create(['name' => 'Tech']);
+
+        $this->tech = User::factory()->create(['status' => User::STATUS_ACTIVE]);
+        $this->tech->assignRole('Tech');
+    }
+
     #[Test]
     public function dashboard_shows_next_calendar_event_when_today_has_no_events(): void
     {
         Carbon::setTestNow(Carbon::parse('2026-05-28 09:00', 'Europe/Oslo'));
-
-        Role::create(['name' => 'Tech']);
-
-        $tech = User::factory()->create(['status' => User::STATUS_ACTIVE]);
-        $tech->assignRole('Tech');
 
         $calendar = Calendar::query()->create([
             'uuid' => (string) Str::uuid(),
@@ -49,10 +58,10 @@ class WarroomDashboardTest extends TestCase
             'status' => 'confirmed',
             'transparency' => 'busy',
             'visibility' => 'public',
-            'created_by' => $tech->id,
+            'created_by' => $this->tech->id,
         ]);
 
-        $this->actingAs($tech)
+        $this->actingAs($this->tech)
             ->get(route('tech.dashboard'))
             ->assertOk()
             ->assertSee('Next event')
@@ -60,5 +69,58 @@ class WarroomDashboardTest extends TestCase
             ->assertDontSee('No upcoming calendar events.');
 
         Carbon::setTestNow();
+    }
+
+    #[Test]
+    public function admin_can_update_warroom_settings(): void
+    {
+        $this->actingAs($this->tech)
+            ->get(route('tech.admin.settings.warroom'))
+            ->assertOk()
+            ->assertViewIs('warroom::Admin.Settings.edit')
+            ->assertSee('Warroom Settings')
+            ->assertSee('Operational Windows');
+
+        $this->actingAs($this->tech)
+            ->put(route('tech.admin.settings.warroom.update'), [
+                'due_soon_hours' => 12,
+                'inbox_recent_hours' => 48,
+                'latest_tickets_limit' => 4,
+                'latest_alerts_limit' => 3,
+                'calendar_today_limit' => 2,
+                'recent_integrations_limit' => 2,
+                'enabled_sections' => ['pulse', 'tickets', 'system_health'],
+            ])
+            ->assertRedirect(route('tech.admin.settings.warroom'));
+
+        $settings = json_decode(CommonSetting::query()->where('type', 'warroom')->where('name', 'dashboard')->value('json'), true);
+
+        $this->assertSame(12, $settings['due_soon_hours']);
+        $this->assertSame(48, $settings['inbox_recent_hours']);
+        $this->assertSame(4, $settings['latest_tickets_limit']);
+        $this->assertSame(['pulse', 'tickets', 'system_health'], $settings['enabled_sections']);
+    }
+
+    #[Test]
+    public function dashboard_respects_visible_panel_settings(): void
+    {
+        app(WarroomSettings::class)->update([
+            'due_soon_hours' => 8,
+            'inbox_recent_hours' => 24,
+            'latest_tickets_limit' => 6,
+            'latest_alerts_limit' => 5,
+            'calendar_today_limit' => 5,
+            'recent_integrations_limit' => 5,
+            'enabled_sections' => ['pulse'],
+        ]);
+
+        $this->actingAs($this->tech)
+            ->get(route('tech.dashboard'))
+            ->assertOk()
+            ->assertSee('Open tickets')
+            ->assertDontSee('Ticket Fireline')
+            ->assertDontSee('Domain Radar')
+            ->assertDontSee('System Health')
+            ->assertDontSee('Next Actions');
     }
 }

--- a/app/Modules/Warroom/Views/Admin/Settings/edit.blade.php
+++ b/app/Modules/Warroom/Views/Admin/Settings/edit.blade.php
@@ -1,0 +1,128 @@
+@extends('layouts.default_tech')
+
+@section('title', 'Warroom Settings')
+
+@section('pageHeader')
+    <div class="d-flex justify-content-between align-items-center gap-2">
+        <h1>Warroom Settings</h1>
+        <x-buttons.back :url="route('tech.admin.index')" class="mb-0">Back</x-buttons.back>
+    </div>
+@endsection
+
+@section('content')
+    <!-- ------------------------------------------------- -->
+    <!-- Warroom Settings Form -->
+    <!-- ------------------------------------------------- -->
+    <form method="POST" action="{{ route('tech.admin.settings.warroom.update') }}">
+        @csrf
+        @method('PUT')
+
+        <div class="card shadow-sm mb-3">
+            <div class="card-header">
+                <h2 class="h6 mb-0">Operational Windows</h2>
+            </div>
+            <div class="card-body">
+                @if(session('success'))
+                    <div class="alert alert-success">{{ session('success') }}</div>
+                @endif
+
+                <div class="row g-3">
+                    <div class="col-lg-6">
+                        <label for="due_soon_hours" class="form-label">SLA due soon window</label>
+                        <div class="input-group">
+                            <input type="number" min="1" max="168" class="form-control @error('due_soon_hours') is-invalid @enderror" id="due_soon_hours" name="due_soon_hours" value="{{ old('due_soon_hours', $settings['due_soon_hours']) }}" required>
+                            <span class="input-group-text">hours</span>
+                            @error('due_soon_hours') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                        </div>
+                    </div>
+
+                    <div class="col-lg-6">
+                        <label for="inbox_recent_hours" class="form-label">Inbox recent window</label>
+                        <div class="input-group">
+                            <input type="number" min="1" max="168" class="form-control @error('inbox_recent_hours') is-invalid @enderror" id="inbox_recent_hours" name="inbox_recent_hours" value="{{ old('inbox_recent_hours', $settings['inbox_recent_hours']) }}" required>
+                            <span class="input-group-text">hours</span>
+                            @error('inbox_recent_hours') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="card shadow-sm mb-3">
+            <div class="card-header">
+                <h2 class="h6 mb-0">List Limits</h2>
+            </div>
+            <div class="card-body">
+                <div class="row g-3">
+                    @foreach([
+                        'latest_tickets_limit' => 'Latest tickets',
+                        'latest_alerts_limit' => 'Latest asset alerts',
+                        'calendar_today_limit' => 'Calendar events today',
+                        'recent_integrations_limit' => 'Recent integrations',
+                    ] as $field => $label)
+                        <div class="col-sm-6 col-xl-3">
+                            <label for="{{ $field }}" class="form-label">{{ $label }}</label>
+                            <input type="number" min="1" max="20" class="form-control @error($field) is-invalid @enderror" id="{{ $field }}" name="{{ $field }}" value="{{ old($field, $settings[$field]) }}" required>
+                            @error($field) <div class="invalid-feedback">{{ $message }}</div> @enderror
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        </div>
+
+        <div class="card shadow-sm">
+            <div class="card-header">
+                <h2 class="h6 mb-0">Visible Panels</h2>
+            </div>
+            <div class="card-body">
+                <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-2">
+                    @foreach($sectionOptions as $value => $label)
+                        <div class="col">
+                            <div class="form-check border rounded p-3 h-100">
+                                <input
+                                    class="form-check-input ms-0 me-2"
+                                    type="checkbox"
+                                    id="enabled_section_{{ $value }}"
+                                    name="enabled_sections[]"
+                                    value="{{ $value }}"
+                                    @checked(in_array($value, old('enabled_sections', $settings['enabled_sections']), true))
+                                >
+                                <label class="form-check-label" for="enabled_section_{{ $value }}">{{ $label }}</label>
+                            </div>
+                        </div>
+                    @endforeach
+                </div>
+                @error('enabled_sections') <div class="text-danger small mt-2">{{ $message }}</div> @enderror
+                @error('enabled_sections.*') <div class="text-danger small mt-2">{{ $message }}</div> @enderror
+
+                <div class="d-flex justify-content-end gap-2 mt-4">
+                    <a href="{{ route('tech.admin.index') }}" class="btn btn-outline-secondary">Cancel</a>
+                    <button type="submit" class="btn btn-primary">Save Settings</button>
+                </div>
+            </div>
+        </div>
+    </form>
+@endsection
+
+@section('sidebar')
+    <x-nav.admin-menu group="warroom" />
+@endsection
+
+@section('rightbar')
+    <!-- ------------------------------------------------- -->
+    <!-- Settings Help -->
+    <!-- ------------------------------------------------- -->
+    <div class="card">
+        <div class="card-header">
+            <h2 class="h6 mb-0">Documentation / Help</h2>
+        </div>
+        <div class="card-body small">
+            <p>
+                Warroom settings control the hardcoded operational dashboard used during beta.
+            </p>
+            <p class="mb-0">
+                Technician-custom dashboards are planned later. These settings are global.
+            </p>
+        </div>
+    </div>
+@endsection

--- a/app/Modules/Warroom/Views/Tech/dashboard.blade.php
+++ b/app/Modules/Warroom/Views/Tech/dashboard.blade.php
@@ -16,96 +16,101 @@
 
 @section('content')
     <!-- Warroom pulse -->
-    <div class="row g-2 mb-3">
-        @foreach($warroom['pulse'] as $metric)
-            <div class="col-12 col-md-6 col-xl-3">
-                <a href="{{ $metric['href'] ?? '#' }}" class="text-decoration-none">
-                    <div class="card border-{{ $metric['tone'] }} h-100">
-                        <div class="card-body py-3">
-                            <div class="d-flex justify-content-between align-items-start">
-                                <div>
-                                    <div class="small text-uppercase text-muted fw-semibold">{{ $metric['label'] }}</div>
-                                    <div class="display-6 fw-semibold text-dark">{{ $metric['value'] }}</div>
+    @if($settings->sectionEnabled($warroom['settings'], 'pulse'))
+        <div class="row g-2 mb-3">
+            @foreach($warroom['pulse'] as $metric)
+                <div class="col-12 col-md-6 col-xl-3">
+                    <a href="{{ $metric['href'] ?? '#' }}" class="text-decoration-none">
+                        <div class="card border-{{ $metric['tone'] }} h-100">
+                            <div class="card-body py-3">
+                                <div class="d-flex justify-content-between align-items-start">
+                                    <div>
+                                        <div class="small text-uppercase text-muted fw-semibold">{{ $metric['label'] }}</div>
+                                        <div class="display-6 fw-semibold text-dark">{{ $metric['value'] }}</div>
+                                    </div>
+                                    <span class="badge text-bg-{{ $metric['tone'] }} rounded-pill">
+                                        <i class="bi {{ $metric['icon'] }}" aria-hidden="true"></i>
+                                    </span>
                                 </div>
-                                <span class="badge text-bg-{{ $metric['tone'] }} rounded-pill">
-                                    <i class="bi {{ $metric['icon'] }}" aria-hidden="true"></i>
-                                </span>
+                                <div class="small text-muted mt-2">{{ $metric['meta'] }}</div>
                             </div>
-                            <div class="small text-muted mt-2">{{ $metric['meta'] }}</div>
                         </div>
-                    </div>
-                </a>
-            </div>
-        @endforeach
-    </div>
+                    </a>
+                </div>
+            @endforeach
+        </div>
+    @endif
 
     <!-- Main operations grid -->
     <div class="row g-3">
         <div class="col-12 col-xl-8">
-            <div class="card mb-3">
-                <div class="card-header py-2 d-flex align-items-center justify-content-between">
-                    <h2 class="h6 mb-0">Ticket Fireline</h2>
-                    @if(Route::has('tech.tickets.index'))
-                        <a href="{{ route('tech.tickets.index') }}" class="btn btn-sm btn-outline-primary">
-                            <i class="bi bi-arrow-right-short" aria-hidden="true"></i> Tickets
-                        </a>
-                    @endif
-                </div>
-                <div class="table-responsive">
-                    <table class="table table-sm table-hover align-middle mb-0">
-                        <thead class="table-light">
-                            <tr>
-                                <th>Ticket</th>
-                                <th>Subject</th>
-                                <th>Signal</th>
-                                <th class="text-end">SLA</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            @forelse($warroom['latest_tickets'] as $ticket)
-                                @php
-                                    $due = $ticket->resolve_due_at ? \Illuminate\Support\Carbon::parse($ticket->resolve_due_at) : null;
-                                    $isOverdue = $due && $due->isPast();
-                                @endphp
+            @if($settings->sectionEnabled($warroom['settings'], 'tickets'))
+                <div class="card mb-3">
+                    <div class="card-header py-2 d-flex align-items-center justify-content-between">
+                        <h2 class="h6 mb-0">Ticket Fireline</h2>
+                        @if(Route::has('tech.tickets.index'))
+                            <a href="{{ route('tech.tickets.index') }}" class="btn btn-sm btn-outline-primary">
+                                <i class="bi bi-arrow-right-short" aria-hidden="true"></i> Tickets
+                            </a>
+                        @endif
+                    </div>
+                    <div class="table-responsive">
+                        <table class="table table-sm table-hover align-middle mb-0">
+                            <thead class="table-light">
                                 <tr>
-                                    <td class="fw-semibold">
-                                        @if(Route::has('tech.tickets.show') && $ticket->ticket_key)
-                                            <a href="{{ route('tech.tickets.show', $ticket->ticket_key) }}" class="text-decoration-none">{{ $ticket->ticket_key }}</a>
-                                        @else
-                                            {{ $ticket->ticket_key ?? '#'.$ticket->id }}
-                                        @endif
-                                    </td>
-                                    <td class="text-truncate">{{ $ticket->subject ?? 'Untitled ticket' }}</td>
-                                    <td>
-                                        @if($ticket->is_unread)
-                                            <span class="badge text-bg-warning">Unread</span>
-                                        @endif
-                                        @if(!$ticket->owner_id)
-                                            <span class="badge text-bg-secondary">Unassigned</span>
-                                        @endif
-                                    </td>
-                                    <td class="text-end">
-                                        @if($due)
-                                            <span class="badge text-bg-{{ $isOverdue ? 'danger' : 'light' }} {{ $isOverdue ? '' : 'text-dark' }}">
-                                                {{ $isOverdue ? 'Overdue' : $due->format('H:i') }}
-                                            </span>
-                                        @else
-                                            <span class="text-muted">-</span>
-                                        @endif
-                                    </td>
+                                    <th>Ticket</th>
+                                    <th>Subject</th>
+                                    <th>Signal</th>
+                                    <th class="text-end">SLA</th>
                                 </tr>
-                            @empty
-                                <tr>
-                                    <td colspan="4" class="text-muted py-4 text-center">No open ticket pressure right now.</td>
-                                </tr>
-                            @endforelse
-                        </tbody>
-                    </table>
+                            </thead>
+                            <tbody>
+                                @forelse($warroom['latest_tickets'] as $ticket)
+                                    @php
+                                        $due = $ticket->resolve_due_at ? \Illuminate\Support\Carbon::parse($ticket->resolve_due_at) : null;
+                                        $isOverdue = $due && $due->isPast();
+                                    @endphp
+                                    <tr>
+                                        <td class="fw-semibold">
+                                            @if(Route::has('tech.tickets.show') && $ticket->ticket_key)
+                                                <a href="{{ route('tech.tickets.show', $ticket->ticket_key) }}" class="text-decoration-none">{{ $ticket->ticket_key }}</a>
+                                            @else
+                                                {{ $ticket->ticket_key ?? '#'.$ticket->id }}
+                                            @endif
+                                        </td>
+                                        <td class="text-truncate">{{ $ticket->subject ?? 'Untitled ticket' }}</td>
+                                        <td>
+                                            @if($ticket->is_unread)
+                                                <span class="badge text-bg-warning">Unread</span>
+                                            @endif
+                                            @if(!$ticket->owner_id)
+                                                <span class="badge text-bg-secondary">Unassigned</span>
+                                            @endif
+                                        </td>
+                                        <td class="text-end">
+                                            @if($due)
+                                                <span class="badge text-bg-{{ $isOverdue ? 'danger' : 'light' }} {{ $isOverdue ? '' : 'text-dark' }}">
+                                                    {{ $isOverdue ? 'Overdue' : $due->format('H:i') }}
+                                                </span>
+                                            @else
+                                                <span class="text-muted">-</span>
+                                            @endif
+                                        </td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="4" class="text-muted py-4 text-center">No open ticket pressure right now.</td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
-            </div>
+            @endif
 
             <div class="row g-3">
-                <div class="col-12 col-lg-6">
+                @if($settings->sectionEnabled($warroom['settings'], 'asset_alerts'))
+                    <div class="col-12 col-lg-6">
                     <div class="card h-100">
                         <div class="card-header py-2 d-flex align-items-center justify-content-between">
                             <h2 class="h6 mb-0">Asset Alerts</h2>
@@ -131,9 +136,11 @@
                             @endforelse
                         </div>
                     </div>
-                </div>
+                    </div>
+                @endif
 
-                <div class="col-12 col-lg-6">
+                @if($settings->sectionEnabled($warroom['settings'], 'calendar'))
+                    <div class="col-12 col-lg-6">
                     <div class="card h-100">
                         <div class="card-header py-2 d-flex align-items-center justify-content-between">
                             <h2 class="h6 mb-0">{{ $warroom['calendar_events_label'] }}</h2>
@@ -162,31 +169,35 @@
                             @endforelse
                         </div>
                     </div>
-                </div>
+                    </div>
+                @endif
             </div>
         </div>
 
         <div class="col-12 col-xl-4">
-            <div class="card mb-3">
-                <div class="card-header py-2">
-                    <h2 class="h6 mb-0">Domain Radar</h2>
-                </div>
-                <div class="list-group list-group-flush">
-                    @foreach($warroom['operations'] as $operation)
-                        <a href="{{ $operation['href'] ?? '#' }}" class="list-group-item list-group-item-action py-2">
-                            <div class="d-flex align-items-center justify-content-between">
-                                <div class="d-flex align-items-center gap-2">
-                                    <span class="text-primary"><i class="bi {{ $operation['icon'] }}" aria-hidden="true"></i></span>
-                                    <span>{{ $operation['label'] }}</span>
+            @if($settings->sectionEnabled($warroom['settings'], 'domain_radar'))
+                <div class="card mb-3">
+                    <div class="card-header py-2">
+                        <h2 class="h6 mb-0">Domain Radar</h2>
+                    </div>
+                    <div class="list-group list-group-flush">
+                        @foreach($warroom['operations'] as $operation)
+                            <a href="{{ $operation['href'] ?? '#' }}" class="list-group-item list-group-item-action py-2">
+                                <div class="d-flex align-items-center justify-content-between">
+                                    <div class="d-flex align-items-center gap-2">
+                                        <span class="text-primary"><i class="bi {{ $operation['icon'] }}" aria-hidden="true"></i></span>
+                                        <span>{{ $operation['label'] }}</span>
+                                    </div>
+                                    <span class="badge text-bg-light text-dark">{{ $operation['value'] }}</span>
                                 </div>
-                                <span class="badge text-bg-light text-dark">{{ $operation['value'] }}</span>
-                            </div>
-                        </a>
-                    @endforeach
+                            </a>
+                        @endforeach
+                    </div>
                 </div>
-            </div>
+            @endif
 
-            <div class="card">
+            @if($settings->sectionEnabled($warroom['settings'], 'integrations'))
+                <div class="card">
                 <div class="card-header py-2 d-flex align-items-center justify-content-between">
                     <h2 class="h6 mb-0">Integration Health</h2>
                     @if(Route::has('tech.admin.system.integrations.index'))
@@ -213,13 +224,15 @@
                     @endforelse
                 </div>
             </div>
+            @endif
         </div>
     </div>
 @endsection
 
 @section('sidebar')
     <!-- Warroom lanes -->
-    <div class="card mb-3">
+    @if($settings->sectionEnabled($warroom['settings'], 'lanes'))
+        <div class="card mb-3">
         <div class="card-header py-2">
             <h2 class="h6 mb-0">Warroom Lanes</h2>
         </div>
@@ -241,6 +254,7 @@
             @endforeach
         </div>
     </div>
+    @endif
 
     <div class="card">
         <div class="card-header py-2">
@@ -265,7 +279,8 @@
 
 @section('rightbar')
     <!-- System health -->
-    <div class="card mb-3">
+    @if($settings->sectionEnabled($warroom['settings'], 'system_health'))
+        <div class="card mb-3">
         <div class="card-header py-2">
             <h2 class="h6 mb-0">System Health</h2>
         </div>
@@ -298,8 +313,10 @@
             </div>
         </div>
     </div>
+    @endif
 
-    <div class="card">
+    @if($settings->sectionEnabled($warroom['settings'], 'next_actions'))
+        <div class="card">
         <div class="card-header py-2">
             <h2 class="h6 mb-0">Next Actions</h2>
         </div>
@@ -318,4 +335,5 @@
             </div>
         </div>
     </div>
+    @endif
 @endsection

--- a/app/Modules/Warroom/routes.php
+++ b/app/Modules/Warroom/routes.php
@@ -1,7 +1,13 @@
 <?php
 
+use App\Modules\Warroom\Controllers\Admin\WarroomSettingsController;
 use App\Modules\Warroom\Controllers\Tech\WarroomController;
 use Illuminate\Support\Facades\Route;
+
+Route::get('/admin/settings/warroom', [WarroomSettingsController::class, 'edit'])
+    ->name('admin.settings.warroom');
+Route::put('/admin/settings/warroom', [WarroomSettingsController::class, 'update'])
+    ->name('admin.settings.warroom.update');
 
 Route::get('/dashboard', WarroomController::class)
     ->name('dashboard');

--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -26,6 +26,7 @@ class PermissionSeeder extends Seeder
     {
         return [
             'warroom.view',
+            'warroom.manage_settings',
 
             'client.view',
             'client.create',
@@ -85,6 +86,7 @@ class PermissionSeeder extends Seeder
             'knowledge.publish',
             'knowledge.sync_bookstack',
             'knowledge.manage_structure',
+            'knowledge.manage_settings',
 
             'documentation.view',
             'documentation.create',

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -64,6 +64,7 @@ class RoleSeeder extends Seeder
                 'task.manage_settings',
                 'calendar.manage_settings',
                 'knowledge.manage_structure',
+                'knowledge.manage_settings',
                 'documentation.manage_templates',
                 'commercial.service_manage',
                 'commercial.contract_manage',
@@ -105,6 +106,7 @@ class RoleSeeder extends Seeder
                 'system.security_manage',
                 'system.backup_manage',
                 'system.settings_manage',
+                'warroom.manage_settings',
                 'report.export',
             ]
         )));

--- a/docs/BETA-COMPLETION-PLAN.md
+++ b/docs/BETA-COMPLETION-PLAN.md
@@ -120,7 +120,7 @@ Modules to audit first:
 - Email and Inbox.
 - Calendar.
 - Notification.
-- Knowledge.
+- Knowledge: manual article defaults are now configurable.
 - Nextcloud.
 - Commercial.
 - Sales.
@@ -219,7 +219,7 @@ Several modules appear to have no clear admin/settings surface yet, or only part
 - Knowledge.
 - Risk.
 - Tasks: manual task defaults are now configurable.
-- Warroom.
+- Warroom: dashboard windows, list limits, and visible panels are now configurable.
 
 Each module needs an ownership review:
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -40,6 +40,8 @@ This file is the shared coordination list for tdPSA development. Use it to deleg
 | Contact Settings Slice | Done | Codex | Contact module now owns defaults and relation type settings. |
 | Legacy Planning Files Cleanup | Done | Codex | Moved Markdown planning/spec files out of production view paths and updated runtime doc references. |
 | Task Settings Slice | Done | Codex | Task module now owns manual task defaults for status, priority, and estimate. |
+| Warroom Settings Slice | Done | Codex | Warroom now owns dashboard windows, list limits, and visible panels. |
+| Knowledge Settings Slice | Done | Codex | Knowledge now owns manual article defaults for visibility, status, review, and priority. |
 | Missing Settings Ownership RFC | In Progress | Codex | RFC approved; implement remaining module settings as slices. |
 | Domain API Foundation | Ready |  | Post-audit platform item. Define and implement consistent APIs for domains that should expose integration surfaces. |
 | Report Builder And Scheduled Client Reporting | Post-Beta |  | Version 2 item. Build custom report builder, saved report templates, and automatic client report delivery. |
@@ -263,6 +265,8 @@ Progress:
 - Asset Settings slice completed.
 - Contact Settings slice completed.
 - Task Settings slice completed.
+- Warroom Settings slice completed.
+- Knowledge Settings slice completed.
 
 ### 12. Domain API Foundation
 

--- a/docs/audits/2026-06-01-module-settings-audit.md
+++ b/docs/audits/2026-06-01-module-settings-audit.md
@@ -50,10 +50,10 @@ These modules need settings ownership decisions before beta is considered clean:
 
 - Asset: manual registration defaults, enabled system asset types, default IP mode, and default manual status are now configurable. RMM sync defaults, alert handling, and related-ticket behavior still need later slices.
 - Contact: default contact type/status and relation type choices are now configurable. Duplicate protection remains mandatory. Communication/language preference defaults still need a later slice.
-- Knowledge: structure permissions, default visibility/status, review defaults, BookStack behavior shortcuts.
+- Knowledge: default visibility, status, review interval, and sort priority are now configurable. BookStack behavior remains Integration-owned.
 - Risk: assessment defaults, scoring defaults, review cadence, settings route.
 - Task: default status, default priority, and default estimate are now configurable. Task templates, checklist defaults, and assignment defaults still need later slices.
-- Warroom: dashboard widget visibility, time windows, and module summary defaults.
+- Warroom: dashboard widget visibility, time windows, and list limits are now configurable.
 - Report: future report export/saved-view settings after more reports exist.
 
 ## Visible Unfinished UI
@@ -90,6 +90,8 @@ Progress:
 - Contact Settings slice completed on 2026-06-01.
 - Legacy Planning Files Cleanup completed on 2026-06-01.
 - Task Settings slice completed on 2026-06-01.
+- Warroom Settings slice completed on 2026-06-01.
+- Knowledge Settings slice completed on 2026-06-01.
 
 ## Not In Scope For This Audit
 

--- a/resources/views/components/nav/admin-menu.blade.php
+++ b/resources/views/components/nav/admin-menu.blade.php
@@ -88,8 +88,14 @@
         'templates' => [
             'name' => 'Templates',
             'route' => 'tech.admin.system.templatesManagement.index',
-            'pattern' => 'tech.admin.system.templatesManagement.*',
+            'pattern' => ['tech.admin.system.templatesManagement.*', 'tech.admin.settings.knowledge*'],
             'icon' => 'bi-layout-text-window-reverse',
+        ],
+        'knowledge' => [
+            'name' => 'Knowledge',
+            'route' => 'tech.admin.settings.knowledge',
+            'pattern' => 'tech.admin.settings.knowledge*',
+            'icon' => 'bi-journal-text',
         ],
         'users' => [
             'name' => 'Users',
@@ -105,10 +111,17 @@
                 'tech.admin.system.tag.*',
                 'tech.admin.system.company-profile.*',
                 'tech.admin.system.branding.*',
+                'tech.admin.settings.warroom*',
                 'tech.admin.system.queues-workers.*',
                 'tech.admin.notification-channels.*',
             ],
             'icon' => 'bi-sliders',
+        ],
+        'warroom' => [
+            'name' => 'Warroom',
+            'route' => 'tech.admin.settings.warroom',
+            'pattern' => 'tech.admin.settings.warroom*',
+            'icon' => 'bi-speedometer2',
         ],
         'integrations' => [
             'name' => 'Integrations',

--- a/resources/views/tech/admin/index.blade.php
+++ b/resources/views/tech/admin/index.blade.php
@@ -91,8 +91,9 @@
         [
             'title' => 'Templates',
             'icon' => 'bi-layout-text-window-reverse',
-            'description' => 'Reusable document and email templates used across modules.',
+            'description' => 'Reusable document, email, and Knowledge defaults used across modules.',
             'links' => [
+                ['label' => 'Knowledge settings', 'route' => route('tech.admin.settings.knowledge')],
                 ['label' => 'Template management', 'route' => route('tech.admin.system.templatesManagement.index')],
             ],
         ],
@@ -114,6 +115,7 @@
             'links' => [
                 ['label' => 'Company profile', 'route' => route('tech.admin.system.company-profile.edit')],
                 ['label' => 'Branding', 'route' => route('tech.admin.system.branding.edit')],
+                ['label' => 'Warroom', 'route' => route('tech.admin.settings.warroom')],
                 ['label' => 'Categories', 'route' => route('tech.admin.system.category.index')],
                 ['label' => 'Tags', 'route' => route('tech.admin.system.tag.index')],
                 ['label' => 'Queues and workers', 'route' => route('tech.admin.system.queues-workers.index')],


### PR DESCRIPTION
- Introduced admin interface for managing manual task creation defaults (status, priority, and estimated minutes).
- Updated logic to apply configured defaults during standalone task creation.
- Enhanced admin views, middleware, and role permissions to support new settings slice.
- Added supporting documentation, tests, and route definitions for task settings management.