### PR TITLE
feat(ui, custom-fields): Add tabbed interface and editable custom fie…

### DIFF
--- a/app/Modules/Clients/Controllers/Tech/ClientCustomFieldValueController.php
+++ b/app/Modules/Clients/Controllers/Tech/ClientCustomFieldValueController.php
@@ -4,6 +4,7 @@ namespace App\Modules\Clients\Controllers\Tech;
 
 use App\Http\Controllers\Controller;
 use App\Models\Clients\Client;
+use App\Models\Clients\ClientSite;
 use App\Modules\CustomField\Actions\SyncCustomFieldValues;
 use App\Modules\CustomField\Models\CustomFieldDefinition;
 use Illuminate\Http\RedirectResponse;
@@ -45,6 +46,34 @@ class ClientCustomFieldValueController extends Controller
 
         return redirect()
             ->route('tech.clients.show', ['client' => $client, 'tab' => 'custom-fields'])
+            ->with('success', "{$definition->label} updated.");
+    }
+
+    public function updateSite(
+        Request $request,
+        ClientSite $site,
+        CustomFieldDefinition $definition,
+        SyncCustomFieldValues $syncCustomFieldValues,
+    ): RedirectResponse {
+        abort_unless($definition->model_type === $site->getMorphClass(), 404);
+
+        $editableDefinitions = $syncCustomFieldValues->definitionsFor($site, $request->user(), 'ui');
+        abort_unless($editableDefinitions->contains('id', $definition->id), 403);
+
+        $validated = $request->validate([
+            'value' => ['nullable'],
+            'value.*' => ['nullable'],
+        ]);
+
+        $syncCustomFieldValues->handle(
+            $site,
+            [$definition->key => $validated['value'] ?? null],
+            $request->user(),
+            'ui',
+        );
+
+        return redirect()
+            ->route('tech.clients.sites.show', ['site' => $site, 'tab' => 'custom-fields'])
             ->with('success', "{$definition->label} updated.");
     }
 }

--- a/app/Modules/Clients/Controllers/Tech/ClientSiteController.php
+++ b/app/Modules/Clients/Controllers/Tech/ClientSiteController.php
@@ -9,6 +9,7 @@ use App\Models\Clients\ClientSite;
 use App\Models\System\Integrations\ClientRmmLink;
 use App\Models\System\Integrations\Integration;
 use App\Modules\Clients\Menus\SideBar\ClientsMenu;
+use App\Modules\CustomField\Support\CustomFieldPresenter;
 use App\Services\Integrations\NAbleRmm\NAbleRmmClient;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -99,7 +100,7 @@ class ClientSiteController extends Controller
      * @param ClientSite $site
      * @return View
      */
-    public function show(ClientSite $site) {
+    public function show(ClientSite $site, Request $request, CustomFieldPresenter $customFieldPresenter) {
 
         // -----------------------------------------
         // Set the active site ID in session
@@ -114,6 +115,7 @@ class ClientSiteController extends Controller
             'site' => $site,
             'client' => $site->client,
             'users' => $site->contacts,
+            'customFields' => $customFieldPresenter->visibleFor($site, $request->user()),
             'sidebarMenuItems' => (new ClientsMenu())->ClientsMenu($site->client),
         ]);
     }

--- a/app/Modules/Clients/Tests/Feature/ClientTechTest.php
+++ b/app/Modules/Clients/Tests/Feature/ClientTechTest.php
@@ -7,6 +7,7 @@ use App\Models\Clients\ClientFormat;
 use App\Models\Clients\ClientSite;
 use App\Models\Clients\ClientUser;
 use App\Models\Core\User;
+use App\Modules\CustomField\Models\CustomFieldDefinition;
 use App\Modules\Task\Actions\StoreTask;
 use App\Modules\Ticket\Actions\EnsureTicketDefaults;
 use App\Modules\Ticket\Models\Ticket;
@@ -425,6 +426,9 @@ class ClientTechTest extends TestCase
         $response->assertSee('Site Profile');
         $response->assertSee('Edit Site');
         $response->assertSee(route('tech.clients.show', $client), false);
+        $response->assertSee('siteWorkspaceTabs', false);
+        $response->assertSee('data-bs-target="#site-assets-pane"', false);
+        $response->assertSee('data-bs-target="#site-users-pane"', false);
         $response->assertSee('Assets');
         $response->assertSee('New Asset');
         $response->assertSee('asset_sort=type', false);
@@ -437,6 +441,51 @@ class ClientTechTest extends TestCase
         $response->assertDontSee('Recent clients');
         $response->assertDontSee('title="View"', false);
         $response->assertDontSee('title="Edit"', false);
+    }
+
+    #[Test]
+    public function site_show_displays_and_edits_visible_custom_fields_in_tabs(): void
+    {
+        $client = Client::factory()->create(['name' => 'Site Custom Field Client AS']);
+        $site = ClientSite::factory()->create(['client_id' => $client->id, 'name' => 'Integration Site']);
+        $definition = CustomFieldDefinition::create([
+            'model_type' => ClientSite::class,
+            'key' => 'msp_manager_site_id',
+            'label' => 'MSP Manager Site ID',
+            'field_type' => 'text',
+            'visible_in_ui' => true,
+            'editable_in_ui' => true,
+            'editable_via_api' => true,
+            'searchable' => true,
+            'unique_per_model' => true,
+            'active' => true,
+        ]);
+
+        $this->actingAs($this->techUser)
+            ->get(route('tech.clients.sites.show', ['site' => $site, 'tab' => 'custom-fields']))
+            ->assertOk()
+            ->assertSee('data-bs-target="#site-custom-fields-pane"', false)
+            ->assertSee('MSP Manager Site ID')
+            ->assertSee('siteCustomFieldValueModal'.$definition->id, false)
+            ->assertSee(route('tech.clients.sites.custom-fields.update', [$site, $definition]), false);
+
+        $this->actingAs($this->techUser)
+            ->patch(route('tech.clients.sites.custom-fields.update', [$site, $definition]), [
+                'value' => 'SITE-777',
+            ])
+            ->assertRedirect(route('tech.clients.sites.show', ['site' => $site, 'tab' => 'custom-fields']));
+
+        $this->assertDatabaseHas('custom_field_values', [
+            'custom_field_definition_id' => $definition->id,
+            'model_type' => ClientSite::class,
+            'model_id' => $site->id,
+            'value_text' => 'SITE-777',
+        ]);
+
+        $this->actingAs($this->techUser)
+            ->get(route('tech.clients.sites.show', ['site' => $site, 'tab' => 'custom-fields']))
+            ->assertOk()
+            ->assertSee('SITE-777');
     }
 
     #[Test]

--- a/app/Modules/Clients/Views/Tech/Sites/show.blade.php
+++ b/app/Modules/Clients/Views/Tech/Sites/show.blade.php
@@ -10,6 +10,24 @@
 @endsection
 
 @section('content')
+    @php
+        $availableTabs = ['assets', 'users', 'custom-fields'];
+        $activeSiteTab = in_array(request('tab'), $availableTabs, true) ? request('tab') : 'assets';
+        if ($activeSiteTab === 'custom-fields' && ($customFields ?? collect())->isEmpty()) {
+            $activeSiteTab = 'assets';
+        }
+        $formatCustomFieldValue = function ($value) {
+            if (is_array($value)) {
+                return $value === [] ? '—' : implode(', ', $value);
+            }
+
+            if (is_bool($value)) {
+                return $value ? 'Yes' : 'No';
+            }
+
+            return filled($value) ? $value : '—';
+        };
+    @endphp
 
     <!-- ------------------------------------------------- -->
     <!-- Sites Info -->
@@ -61,66 +79,161 @@
     </div>
 
     <!-- ------------------------------------------------- -->
-    <!-- ASSETS -->
+    <!-- Site Workspace Tabs -->
     <!-- ------------------------------------------------- -->
-    <x-tech.assets.list-card :site="$site" />
+    <ul class="nav nav-tabs border-bottom border-secondary-subtle" id="siteWorkspaceTabs" role="tablist">
+        <li class="nav-item" role="presentation">
+            <button class="nav-link {{ $activeSiteTab === 'assets' ? 'active ' : '' }}text-body border border-bottom-0" id="site-assets-tab" data-bs-toggle="tab" data-bs-target="#site-assets-pane" type="button" role="tab" aria-controls="site-assets-pane" aria-selected="{{ $activeSiteTab === 'assets' ? 'true' : 'false' }}">
+                Assets
+            </button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link {{ $activeSiteTab === 'users' ? 'active ' : '' }}text-body border border-bottom-0" id="site-users-tab" data-bs-toggle="tab" data-bs-target="#site-users-pane" type="button" role="tab" aria-controls="site-users-pane" aria-selected="{{ $activeSiteTab === 'users' ? 'true' : 'false' }}">
+                Users <span class="badge text-bg-light border ms-1">{{ $users->count() }}</span>
+            </button>
+        </li>
+        @if(($customFields ?? collect())->isNotEmpty())
+            <li class="nav-item" role="presentation">
+                <button class="nav-link {{ $activeSiteTab === 'custom-fields' ? 'active ' : '' }}text-body border border-bottom-0" id="site-custom-fields-tab" data-bs-toggle="tab" data-bs-target="#site-custom-fields-pane" type="button" role="tab" aria-controls="site-custom-fields-pane" aria-selected="{{ $activeSiteTab === 'custom-fields' ? 'true' : 'false' }}">
+                    Custom Fields <span class="badge text-bg-light border ms-1">{{ $customFields->count() }}</span>
+                </button>
+            </li>
+        @endif
+    </ul>
 
-    <!-- ------------------------------------------------- -->
-    <!-- USERS - Shows user_management of the site in an table -->
-    <!-- ------------------------------------------------- -->
-    <div class="card">
-        <div class="card-header d-flex justify-content-between align-items-center">
-            <div class="d-flex align-items-center gap-2">
-                <h2 class="h5 mb-0">Users</h2>
-                <span class="badge text-bg-secondary">{{ $users->count() }}</span>
+    <div class="tab-content pt-3" id="siteWorkspaceTabsContent">
+        <div @class(['tab-pane fade', 'show active' => $activeSiteTab === 'assets']) id="site-assets-pane" role="tabpanel" aria-labelledby="site-assets-tab" tabindex="0">
+            <x-tech.assets.list-card :site="$site" />
+        </div>
+
+        <div @class(['tab-pane fade', 'show active' => $activeSiteTab === 'users']) id="site-users-pane" role="tabpanel" aria-labelledby="site-users-tab" tabindex="0">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <div class="d-flex align-items-center gap-2">
+                        <h2 class="h5 mb-0">Users</h2>
+                        <span class="badge text-bg-secondary">{{ $users->count() }}</span>
+                    </div>
+                    <x-buttons.addlink url="{{ route('tech.clients.user.create', $client) }}" class="mb-0">New User</x-buttons.addlink>
+                </div>
+
+                <div class="table-responsive">
+                    <table class="table table-sm table-hover align-middle mb-0">
+                        <thead class="table-light">
+                        <tr>
+                            <th>Name</th>
+                            <th>Role</th>
+                            <th>E-mail</th>
+                            <th>Phone</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+
+                        <!-- ------------------------------------------------- -->
+                        <!-- For each user_management -->
+                        <!-- ------------------------------------------------- -->
+                        @forelse($users as $user)
+                            <tr class="cursor-pointer" data-href="{{ route('tech.clients.user.show', $user) }}" onclick="window.location.href = this.dataset.href">
+                                <td>{{ $user->name }}</td>
+                                <td>{{ $user->role ?: '—' }}</td>
+                                <td>
+                                    @if($user->email)
+                                        <a href="mailto:{{ $user->email }}" onclick="event.stopPropagation()">{{ $user->email }}</a>
+                                    @else
+                                        <span class="text-muted">—</span>
+                                    @endif
+                                </td>
+                                <td>
+                                    @if($user->phone)
+                                        <a href="tel:{{ $user->phone }}" onclick="event.stopPropagation()">{{ $user->phone }}</a>
+                                    @else
+                                        <span class="text-muted">—</span>
+                                    @endif
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="4" class="text-muted">No users found.</td>
+                            </tr>
+                        @endforelse
+
+                        </tbody>
+                    </table>
+                </div>
             </div>
-            <x-buttons.addlink url="{{ route('tech.clients.user.create', $client) }}" class="mb-0">New User</x-buttons.addlink>
         </div>
 
-        <div class="table-responsive">
-            <table class="table table-sm table-hover align-middle mb-0">
-                <thead class="table-light">
-                <tr>
-                    <th>Name</th>
-                    <th>Role</th>
-                    <th>E-mail</th>
-                    <th>Phone</th>
-                </tr>
-                </thead>
-                <tbody>
-
-                <!-- ------------------------------------------------- -->
-                <!-- For each user_management -->
-                <!-- ------------------------------------------------- -->
-                @forelse($users as $user)
-                    <tr class="cursor-pointer" data-href="{{ route('tech.clients.user.show', $user) }}" onclick="window.location.href = this.dataset.href">
-                        <td>{{ $user->name }}</td>
-                        <td>{{ $user->role ?: '—' }}</td>
-                        <td>
-                            @if($user->email)
-                                <a href="mailto:{{ $user->email }}" onclick="event.stopPropagation()">{{ $user->email }}</a>
-                            @else
-                                <span class="text-muted">—</span>
-                            @endif
-                        </td>
-                        <td>
-                            @if($user->phone)
-                                <a href="tel:{{ $user->phone }}" onclick="event.stopPropagation()">{{ $user->phone }}</a>
-                            @else
-                                <span class="text-muted">—</span>
-                            @endif
-                        </td>
-                    </tr>
-                @empty
-                    <tr>
-                        <td colspan="4" class="text-muted">No users found.</td>
-                    </tr>
-                @endforelse
-
-                </tbody>
-            </table>
-        </div>
+        @if(($customFields ?? collect())->isNotEmpty())
+            <div @class(['tab-pane fade', 'show active' => $activeSiteTab === 'custom-fields']) id="site-custom-fields-pane" role="tabpanel" aria-labelledby="site-custom-fields-tab" tabindex="0">
+                <div class="card">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <div class="d-flex align-items-center gap-2">
+                            <h2 class="h5 mb-0">Custom Fields</h2>
+                            <span class="badge text-bg-light border">{{ $customFields->count() }}</span>
+                        </div>
+                        <span class="small text-muted">Visible site fields</span>
+                    </div>
+                    <div class="table-responsive">
+                        <table class="table table-sm table-hover align-middle mb-0">
+                            <thead class="table-light">
+                                <tr>
+                                    <th>Field</th>
+                                    <th>Value</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach($customFields as $field)
+                                    @php
+                                        $modalId = 'siteCustomFieldValueModal'.$field['definition']->id;
+                                        $canEditCustomField = (bool) $field['can_edit'];
+                                    @endphp
+                                    <tr @class(['cursor-pointer' => $canEditCustomField]) @if($canEditCustomField) data-bs-toggle="modal" data-bs-target="#{{ $modalId }}" @endif>
+                                        <td>
+                                            <div class="fw-semibold">{{ $field['label'] }}</div>
+                                            @if(filled($field['help_text']))
+                                                <div class="small text-muted">{{ $field['help_text'] }}</div>
+                                            @endif
+                                        </td>
+                                        <td @class(['text-muted' => blank($field['value']) && $field['value'] !== false])>
+                                            {{ $formatCustomFieldValue($field['value']) }}
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        @endif
     </div>
+
+    @foreach(($customFields ?? collect()) as $field)
+        @continue(! $field['can_edit'])
+        @php $modalId = 'siteCustomFieldValueModal'.$field['definition']->id; @endphp
+        <div class="modal fade" id="{{ $modalId }}" tabindex="-1" aria-labelledby="{{ $modalId }}Label" aria-hidden="true">
+            <div class="modal-dialog">
+                <form method="POST" action="{{ route('tech.clients.sites.custom-fields.update', [$site, $field['definition']]) }}" class="modal-content">
+                    @csrf
+                    @method('PATCH')
+                    <div class="modal-header">
+                        <h2 class="modal-title fs-5" id="{{ $modalId }}Label">{{ $field['label'] }}</h2>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <label class="form-label" for="{{ $modalId }}Value">Value</label>
+                        @include('customfield::components.value-input', [
+                            'field' => $field,
+                            'inputName' => 'value',
+                            'inputId' => $modalId.'Value',
+                        ])
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-primary">Save value</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    @endforeach
 
 @endsection
 

--- a/app/Modules/Clients/routes.php
+++ b/app/Modules/Clients/routes.php
@@ -19,6 +19,7 @@ Route::put('/clients/sites/update/{site}/{client?}', [\App\Modules\Clients\Contr
 Route::delete('/clients/sites/destroy/{site}', [\App\Modules\Clients\Controllers\Tech\ClientSiteController::class, 'destroy'])->name('clients.sites.destroy');
 Route::get('/clients/sites/create/{client?}', [\App\Modules\Clients\Controllers\Tech\ClientSiteController::class, 'create'])->name('clients.sites.create');
 Route::post('/clients/sites/store/{client?}', [\App\Modules\Clients\Controllers\Tech\ClientSiteController::class, 'store'])->name('clients.sites.store');
+Route::patch('/clients/sites/{site}/custom-fields/{definition}', [ClientCustomFieldValueController::class, 'updateSite'])->name('clients.sites.custom-fields.update');
 
 // Users
 Route::get('/clients/users/{client?}', [\App\Modules\Clients\Controllers\Tech\ClientUsersController::class, 'index'])->name('clients.users.index');


### PR DESCRIPTION
…lds for Client Sites

- Introduced a tabbed UI for Client Sites to organize Assets, Users, and Custom Fields.
- Enabled viewing and updating custom field values directly from the Custom Fields tab.
- Added feature tests for custom field visibility, editing, and persistence.
- Updated controllers, routes, and Blade views to support the new functionality.