### PR TITLE
fix: add dedicated updateTalkBot route and controller method

### DIFF
--- a/app/Modules/Clients/Controllers/Tech/ClientController.php
+++ b/app/Modules/Clients/Controllers/Tech/ClientController.php
@@ -19,6 +19,9 @@ use Illuminate\View\View;
 
 class ClientController extends Controller
 {
+    private const CLIENT_FILTER_SESSION_KEY = 'clients.index.filters';
+    private const CLIENT_FILTER_TTL_MINUTES = 120;
+
     /**
      * Display a paginated list of clients.
      *
@@ -28,31 +31,94 @@ class ClientController extends Controller
      * @param Request $request
      * @return View
      */
-    public function index(Request $request): View
+    public function index(Request $request): View|RedirectResponse
     {
         // -----------------------------------------
         // Reset active client ID in session
         // -----------------------------------------
         session()->forget(['active_client_id', 'active_site_id']);
 
-        $query = Client::query()->with(['clientFormat', 'riskAssessments.items']);
+        if ($request->boolean('clear_filters')) {
+            session()->forget(self::CLIENT_FILTER_SESSION_KEY);
 
-        if ($search = $request->get('search')) {
+            return redirect()->route('tech.clients.index');
+        }
+
+        $filterKeys = ['search', 'status', 'format_id', 'contract_filter', 'rmm_filter'];
+        $hasIncomingFilters = collect($filterKeys)->contains(fn (string $key): bool => $request->has($key));
+        $storedFilters = session(self::CLIENT_FILTER_SESSION_KEY);
+
+        if (! $hasIncomingFilters && is_array($storedFilters ?? null)) {
+            $storedAt = $storedFilters['stored_at'] ?? null;
+            $isExpired = ! $storedAt || now()->diffInMinutes($storedAt) > self::CLIENT_FILTER_TTL_MINUTES;
+
+            if ($isExpired) {
+                session()->forget(self::CLIENT_FILTER_SESSION_KEY);
+                $filters = array_fill_keys($filterKeys, null);
+            } else {
+                $filters = array_merge(array_fill_keys($filterKeys, null), $storedFilters['filters'] ?? []);
+            }
+        } else {
+            $filters = array_merge(array_fill_keys($filterKeys, null), $request->only($filterKeys));
+            $filters = array_map(fn ($value) => is_string($value) ? trim($value) : $value, $filters);
+
+            session([
+                self::CLIENT_FILTER_SESSION_KEY => [
+                    'filters' => $filters,
+                    'stored_at' => now(),
+                ],
+            ]);
+        }
+
+        $query = Client::query()
+            ->select('clients.*')
+            ->with(['clientFormat', 'riskAssessments.items'])
+            ->withCount(['sites', 'contacts', 'contracts']);
+
+        if ($search = $filters['search']) {
             $query->where(function($q) use ($search) {
                 $q->where('clients.name', 'like', "%$search%");
+                $q->orWhere('clients.client_number', 'like', "%$search%");
                 $q->orWhere('clients.org_no', 'like', "%$search%");
                 $q->orWhere('clients.billing_email', 'like', "%$search%");
             });
+        }
+
+        if (($filters['status'] ?? '') === 'active') {
+            $query->where('clients.active', true);
+        } elseif (($filters['status'] ?? '') === 'inactive') {
+            $query->where('clients.active', false);
+        }
+
+        if (filled($filters['format_id'] ?? null)) {
+            $query->where('clients.client_format_id', (int) $filters['format_id']);
+        }
+
+        if (($filters['contract_filter'] ?? '') === 'without_contract') {
+            $query->doesntHave('contracts');
+        } elseif (($filters['contract_filter'] ?? '') === 'with_contract') {
+            $query->has('contracts');
+        } elseif (($filters['contract_filter'] ?? '') === 'won_contract') {
+            $query->whereHas('contracts', fn ($contracts) => $contracts->where('approval_status', 'won'));
+        }
+
+        $rmmIntegration = Integration::query()->where('type', 'rmm')->first();
+        if ($rmmIntegration && ($filters['rmm_filter'] ?? '') === 'linked') {
+            $query->whereHas('rmmLinks', fn ($links) => $links->where('integration_id', $rmmIntegration->id));
+        } elseif ($rmmIntegration && ($filters['rmm_filter'] ?? '') === 'unlinked') {
+            $query->whereDoesntHave('rmmLinks', fn ($links) => $links->where('integration_id', $rmmIntegration->id));
         }
 
         $sort = $request->get('sort', 'name');
         $direction = $request->get('direction', 'asc') === 'desc' ? 'desc' : 'asc';
         $sortableColumns = [
             'name' => 'clients.name',
+            'client_number' => 'clients.client_number',
             'org_no' => 'clients.org_no',
             'format' => 'client_formats.code',
             'billing_email' => 'clients.billing_email',
             'status' => 'clients.active',
+            'contracts' => 'contracts_count',
         ];
 
         if (! array_key_exists($sort, $sortableColumns)) {
@@ -60,8 +126,7 @@ class ClientController extends Controller
         }
 
         if ($sort === 'format') {
-            $query->leftJoin('client_formats', 'client_formats.id', '=', 'clients.client_format_id')
-                ->select('clients.*');
+            $query->leftJoin('client_formats', 'client_formats.id', '=', 'clients.client_format_id');
         }
 
         // -----------------------------------------
@@ -73,14 +138,22 @@ class ClientController extends Controller
             ->paginate(25)
             ->withQueryString();
 
+        $activeFilterCount = collect($filters)
+            ->filter(fn ($value): bool => filled($value))
+            ->count();
+
         // -----------------------------------------
         // Retun View:
         // -----------------------------------------
         return view('clients::Tech.index', [
             'clients' => $clients,
-            'search' => $search,
+            'filters' => $filters,
+            'search' => $filters['search'],
             'sort' => $sort,
             'direction' => $direction,
+            'clientFormats' => ClientFormat::activeOptions(),
+            'activeFilterCount' => $activeFilterCount,
+            'rmmIntegration' => $rmmIntegration,
             'sidebarMenuItems' => (new ClientsMenu())->ClientsMenu(null),
         ]);
     }

--- a/app/Modules/Clients/Controllers/Tech/ClientSettingsController.php
+++ b/app/Modules/Clients/Controllers/Tech/ClientSettingsController.php
@@ -4,11 +4,13 @@ namespace App\Modules\Clients\Controllers\Tech;
 
 use App\Http\Controllers\Controller;
 use App\Models\Clients\Client;
+use App\Models\Clients\ClientFormat;
 use App\Models\System\Integrations\Integration;
 use App\Modules\CustomField\Actions\SyncCustomFieldValues;
 use App\Modules\CustomField\Support\CustomFieldPresenter;
 use App\Services\Integrations\NAbleRmm\NAbleRmmClient;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class ClientSettingsController extends Controller
 {
@@ -40,20 +42,45 @@ class ClientSettingsController extends Controller
             'rmmClients' => $rmmClients,
             'rmmError' => $rmmError,
             'currentRmmId' => $currentRmmId,
+            'clientFormats' => ClientFormat::activeOptions(),
             'customFields' => $customFields->editableFor($client, $request->user()),
         ]);
     }
 
     public function update(Request $request, Client $client, SyncCustomFieldValues $customFields)
     {
-        $request->validate([
-            'rmm_external_id' => 'nullable|string',
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'client_number' => [
+                'nullable',
+                'string',
+                'regex:/^\d{5}$/',
+                Rule::unique('clients', 'client_number')->ignore($client->id),
+            ],
+            'org_no' => ['nullable', 'string', 'max:50'],
+            'client_format_id' => ['nullable', Rule::exists('client_formats', 'id')],
+            'website' => ['nullable', 'string', 'max:255'],
+            'billing_email' => ['nullable', 'email', 'max:255'],
+            'notes' => ['nullable', 'string'],
+            'active' => ['nullable', 'boolean'],
+            'rmm_external_id' => ['nullable', 'string'],
             'custom_fields' => ['nullable', 'array'],
         ]);
 
+        $client->forceFill([
+            'name' => $validated['name'],
+            'client_number' => $validated['client_number'] ?? null,
+            'org_no' => $validated['org_no'] ?? null,
+            'client_format_id' => $validated['client_format_id'] ?? null,
+            'website' => $validated['website'] ?? null,
+            'billing_email' => $validated['billing_email'] ?? null,
+            'notes' => $validated['notes'] ?? null,
+            'active' => $request->boolean('active'),
+        ])->save();
+
         $rmmIntegration = Integration::where('type', 'rmm')->where('status', 'active')->first();
-        if ($rmmIntegration) {
-            if ($request->rmm_external_id) {
+        if ($rmmIntegration && $request->has('rmm_external_id')) {
+            if ($validated['rmm_external_id'] ?? null) {
                 \App\Models\System\Integrations\ClientRmmLink::updateOrCreate(
                     [
                         'integration_id' => $rmmIntegration->id,

--- a/app/Modules/Clients/Docs/knowledge/client-domain-overview.md
+++ b/app/Modules/Clients/Docs/knowledge/client-domain-overview.md
@@ -13,6 +13,17 @@ Opening a Client sets `active_client_id` in the technician session. Opening a Si
 The Client index clears active client and site context so technicians can return to a global client
 view.
 
+## Technician UI
+
+The Client show page uses the gear action in the Summary card as the Client edit entry point.
+This edit surface updates core Client fields, Client status, the N-able RMM mapping, and editable
+Client custom field values.
+
+The Client index has a compact search row and an advanced filter panel behind the funnel icon.
+Technicians can filter by active status, Client format, contract presence, won contracts, and RMM
+link state when RMM is configured. Client index filters are remembered in the technician session for
+two hours or until the technician uses `Clear`.
+
 ## Sites
 
 Sites are physical or operational locations for a Client. Each Client should have a default Site so

--- a/app/Modules/Clients/Tests/Feature/ClientTechTest.php
+++ b/app/Modules/Clients/Tests/Feature/ClientTechTest.php
@@ -7,6 +7,8 @@ use App\Models\Clients\ClientFormat;
 use App\Models\Clients\ClientSite;
 use App\Models\Clients\ClientUser;
 use App\Models\Core\User;
+use App\Models\System\Integrations\Integration;
+use App\Modules\Commercial\Models\Contracts\Contracts;
 use App\Modules\CustomField\Models\CustomFieldDefinition;
 use App\Modules\Task\Actions\StoreTask;
 use App\Modules\Ticket\Actions\EnsureTicketDefaults;
@@ -263,6 +265,97 @@ class ClientTechTest extends TestCase
         $response->assertDontSee('Client Sites');
         $response->assertDontSee('Back to Clients');
         $this->assertEquals($client->id, session('active_client_id'));
+    }
+
+    #[Test]
+    public function client_settings_edit_updates_client_details_status_and_rmm_link(): void
+    {
+        $format = ClientFormat::query()->where('code', 'AS')->firstOrFail();
+        $client = Client::factory()->create([
+            'name' => 'Editable Client AS',
+            'client_number' => '12345',
+            'active' => true,
+        ]);
+        $integration = Integration::query()->create([
+            'name' => 'N-able RMM',
+            'type' => 'rmm',
+            'status' => 'active',
+            'base_url' => 'https://rmm.example.test',
+        ]);
+
+        $this->actingAs($this->techUser)
+            ->get(route('tech.clients.settings.edit', $client))
+            ->assertOk()
+            ->assertViewIs('clients::Tech.Settings.edit')
+            ->assertSee('Edit Client')
+            ->assertSee('Client Details')
+            ->assertSee('N-able RMM Integration');
+
+        $this->actingAs($this->techUser)
+            ->put(route('tech.clients.settings.update', $client), [
+                'name' => 'Edited Client AS',
+                'client_number' => '54321',
+                'org_no' => '999888777',
+                'client_format_id' => $format->id,
+                'website' => 'https://edited.example.test',
+                'billing_email' => 'billing@edited.example.test',
+                'notes' => 'Updated during import cleanup.',
+                'active' => '0',
+                'rmm_external_id' => 'RMM-CLIENT-42',
+            ])
+            ->assertRedirect(route('tech.clients.show', $client->id));
+
+        $this->assertDatabaseHas('clients', [
+            'id' => $client->id,
+            'name' => 'Edited Client AS',
+            'client_number' => '54321',
+            'active' => false,
+            'billing_email' => 'billing@edited.example.test',
+        ]);
+        $this->assertDatabaseHas('client_rmm_links', [
+            'integration_id' => $integration->id,
+            'linkable_type' => Client::class,
+            'linkable_id' => $client->id,
+            'external_id' => 'RMM-CLIENT-42',
+        ]);
+    }
+
+    #[Test]
+    public function client_index_filters_without_contracts_and_remembers_until_clear(): void
+    {
+        $withoutContract = Client::factory()->create(['name' => 'No Contract Client AS']);
+        $withContract = Client::factory()->create(['name' => 'Contracted Client AS']);
+        Contracts::query()->create([
+            'client_id' => $withContract->id,
+            'description' => 'Managed services',
+            'start_date' => now()->toDateString(),
+            'approval_status' => 'won',
+            'created_by' => $this->techUser->id,
+        ]);
+
+        $this->actingAs($this->techUser)
+            ->get(route('tech.clients.index', ['contract_filter' => 'without_contract']))
+            ->assertOk()
+            ->assertSee('No Contract Client AS')
+            ->assertDontSee('Contracted Client AS')
+            ->assertSee('clientAdvancedFilters', false)
+            ->assertSee('Clear');
+
+        $this->actingAs($this->techUser)
+            ->get(route('tech.clients.index'))
+            ->assertOk()
+            ->assertSee('No Contract Client AS')
+            ->assertDontSee('Contracted Client AS');
+
+        $this->actingAs($this->techUser)
+            ->get(route('tech.clients.index', ['clear_filters' => 1]))
+            ->assertRedirect(route('tech.clients.index'));
+
+        $this->actingAs($this->techUser)
+            ->get(route('tech.clients.index'))
+            ->assertOk()
+            ->assertSee('No Contract Client AS')
+            ->assertSee('Contracted Client AS');
     }
 
     #[Test]

--- a/app/Modules/Clients/Views/Tech/Settings/edit.blade.php
+++ b/app/Modules/Clients/Views/Tech/Settings/edit.blade.php
@@ -1,136 +1,175 @@
 @extends('layouts.default_tech')
 
 @section('pageHeader')
-    <div class="d-flex justify-content-between align-items-center">
-        <h1>Client Settings</h1>
-        <div>
-            <x-buttons.back url="{{ route('tech.clients.show', $client->id) }}" class="mb-0">Back</x-buttons.back>
-        </div>
+    <div class="d-flex justify-content-between align-items-center gap-2">
+        <h1>Edit Client</h1>
+        <x-buttons.back url="{{ route('tech.clients.show', $client->id) }}" class="mb-0">Back</x-buttons.back>
     </div>
 @endsection
 
 @section('content')
-    <!-- ------------------------------------------------- -->
-    <!-- Client settings context -->
-    <!-- ------------------------------------------------- -->
-    <div class="card mb-3">
-        <div class="card-header">
-            <h2 class="h5 mb-0">{{ $client->name }}</h2>
-        </div>
-    </div>
+    <form action="{{ route('tech.clients.settings.update', $client->id) }}" method="POST">
+        @csrf
+        @method('PUT')
 
-    {{-- N-able RMM Link Card --}}
-    @if($rmmIntegration && $rmmIntegration->status === 'active')
+        <!-- ------------------------------------------------- -->
+        <!-- Client details -->
+        <!-- ------------------------------------------------- -->
         <div class="card mb-3">
-            <div class="card-header">
-                <h2 class="h5 mb-0">N-able RMM Integration</h2>
-            </div>
-            <div class="card-body">
-                @if(isset($rmmError))
-                    <div class="alert alert-warning">
-                        <i class="bi bi-exclamation-triangle-fill me-2"></i>
-                        <strong>Warning:</strong> Could not fetch clients from N-able RMM.
-                        <p class="mb-0 small text-muted mt-1">{{ $rmmError }}</p>
-                    </div>
-                @endif
-
-                <form action="{{ route('tech.clients.settings.update', $client->id) }}" method="POST">
-                    @csrf
-                    @method('PUT')
-
-                    <div class="mb-3">
-                        <label for="rmm_external_id" class="form-label">Link to N-able RMM Client (Mapping)</label>
-                        <select name="rmm_external_id" id="rmm_external_id" class="form-select" {{ isset($rmmError) ? 'disabled' : '' }}>
-                            <option value="">-- {{ isset($rmmError) ? 'Error fetching clients' : 'Select RMM Client' }} --</option>
-                            @foreach($rmmClients as $rmmClient)
-                                <option value="{{ $rmmClient['clientid'] }}" {{ ($currentRmmId ?? '') == $rmmClient['clientid'] ? 'selected' : '' }}>
-                                    {{ $rmmClient['name'] }} ({{ $rmmClient['clientid'] }})
-                                </option>
-                            @endforeach
-                        </select>
-                        <small class="text-muted">Select the corresponding client in N-able RMM to enable synchronization.</small>
-                    </div>
-
-                    <button type="submit" class="btn btn-primary" {{ isset($rmmError) ? 'disabled' : '' }}>Save Settings</button>
-                </form>
-            </div>
-        </div>
-    @endif
-
-    {{-- Custom Fields --}}
-    @if(($customFields ?? collect())->isNotEmpty())
-        <form action="{{ route('tech.clients.settings.update', $client->id) }}" method="POST" class="card mb-3">
-            @csrf
-            @method('PUT')
-            <div class="card-header">
-                <h2 class="h5 mb-0">Custom Fields</h2>
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <h2 class="h5 mb-0">Client Details</h2>
+                <span class="badge {{ $client->active ? 'text-bg-success' : 'text-bg-secondary' }}">
+                    {{ $client->active ? 'Active' : 'Inactive' }}
+                </span>
             </div>
             <div class="card-body">
                 <div class="row g-3">
-                    @foreach($customFields as $field)
-                        @php($definition = $field['definition'])
-                        <div class="col-md-6">
-                            <label class="form-label" for="customField{{ $definition->id }}">
-                                {{ $field['label'] }}
-                                @if($field['required'])
-                                    <span class="text-danger">*</span>
-                                @endif
-                            </label>
+                    <div class="col-md-2">
+                        <label for="client_number" class="form-label fw-semibold">Client number</label>
+                        <input id="client_number" type="text" name="client_number" value="{{ old('client_number', $client->client_number) }}" class="form-control @error('client_number') is-invalid @enderror" placeholder="00000">
+                        @error('client_number')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
 
-                            @if(in_array($field['type'], ['textarea'], true))
-                                <textarea id="customField{{ $definition->id }}" name="custom_fields[{{ $field['key'] }}]" rows="3" class="form-control @error('custom_fields.'.$field['key']) is-invalid @enderror">{{ old('custom_fields.'.$field['key'], $field['value']) }}</textarea>
-                            @elseif($field['type'] === 'select')
-                                <select id="customField{{ $definition->id }}" name="custom_fields[{{ $field['key'] }}]" class="form-select @error('custom_fields.'.$field['key']) is-invalid @enderror">
-                                    <option value="">—</option>
-                                    @foreach($field['options'] as $option)
-                                        <option value="{{ $option }}" @selected(old('custom_fields.'.$field['key'], $field['value']) === $option)>{{ $option }}</option>
-                                    @endforeach
-                                </select>
-                            @elseif($field['type'] === 'multiselect')
-                                <select id="customField{{ $definition->id }}" name="custom_fields[{{ $field['key'] }}][]" class="form-select @error('custom_fields.'.$field['key']) is-invalid @enderror" multiple>
-                                    @foreach($field['options'] as $option)
-                                        <option value="{{ $option }}" @selected(in_array($option, old('custom_fields.'.$field['key'], $field['value'] ?? []), true))>{{ $option }}</option>
-                                    @endforeach
-                                </select>
-                            @elseif($field['type'] === 'checkbox')
-                                <input type="hidden" name="custom_fields[{{ $field['key'] }}]" value="0">
-                                <div class="form-check">
-                                    <input id="customField{{ $definition->id }}" type="checkbox" name="custom_fields[{{ $field['key'] }}]" value="1" class="form-check-input @error('custom_fields.'.$field['key']) is-invalid @enderror" @checked(old('custom_fields.'.$field['key'], $field['value']))>
-                                    <label class="form-check-label" for="customField{{ $definition->id }}">Enabled</label>
-                                </div>
-                            @else
-                                <input id="customField{{ $definition->id }}" type="{{ match($field['type']) { 'number' => 'number', 'date' => 'date', 'datetime' => 'datetime-local', 'email' => 'email', 'url' => 'url', default => 'text' } }}" name="custom_fields[{{ $field['key'] }}]" value="{{ old('custom_fields.'.$field['key'], $field['value']) }}" class="form-control @error('custom_fields.'.$field['key']) is-invalid @enderror">
-                            @endif
+                    <div class="col-md-5">
+                        <label for="name" class="form-label fw-semibold">Name *</label>
+                        <input id="name" type="text" name="name" value="{{ old('name', $client->name) }}" required class="form-control @error('name') is-invalid @enderror">
+                        @error('name')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
 
-                            @error('custom_fields.'.$field['key'])
-                                <div class="invalid-feedback d-block">{{ $message }}</div>
-                            @enderror
-                            @if($field['help_text'])
-                                <div class="form-text">{{ $field['help_text'] }}</div>
-                            @endif
+                    <div class="col-md-3">
+                        <label for="org_no" class="form-label fw-semibold">Org No</label>
+                        <input id="org_no" type="text" name="org_no" value="{{ old('org_no', $client->org_no) }}" class="form-control @error('org_no') is-invalid @enderror">
+                        @error('org_no')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="col-md-2">
+                        <label for="client_format_id" class="form-label fw-semibold">Format</label>
+                        <select id="client_format_id" name="client_format_id" class="form-select @error('client_format_id') is-invalid @enderror">
+                            <option value="">—</option>
+                            @foreach(($clientFormats ?? []) as $format)
+                                <option value="{{ $format->id }}" @selected((string) old('client_format_id', $client->client_format_id) === (string) $format->id)>{{ $format->code }}</option>
+                            @endforeach
+                        </select>
+                        @error('client_format_id')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="col-md-4">
+                        <label for="billing_email" class="form-label fw-semibold">Billing Email</label>
+                        <input id="billing_email" type="email" name="billing_email" value="{{ old('billing_email', $client->billing_email) }}" class="form-control @error('billing_email') is-invalid @enderror">
+                        @error('billing_email')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="col-md-4">
+                        <label for="website" class="form-label fw-semibold">Website</label>
+                        <input id="website" type="text" name="website" value="{{ old('website', $client->website) }}" class="form-control @error('website') is-invalid @enderror">
+                        @error('website')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="col-md-4">
+                        <label class="form-label fw-semibold d-block">Status</label>
+                        <input type="hidden" name="active" value="0">
+                        <div class="form-check form-switch mt-2">
+                            <input id="active" type="checkbox" name="active" value="1" class="form-check-input" @checked(old('active', $client->active))>
+                            <label class="form-check-label" for="active">Client is active</label>
                         </div>
-                    @endforeach
-                </div>
-            </div>
-            <div class="card-footer d-flex justify-content-end">
-                <button type="submit" class="btn btn-primary">Save Custom Fields</button>
-            </div>
-        </form>
-    @endif
+                    </div>
 
-    {{-- Other settings cards can be added here later --}}
-    <div class="accordion" id="clientSettingsAccordion">
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="generalSettingsHeader">
-                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#generalSettingsCollapse" aria-expanded="false" aria-controls="generalSettingsCollapse">
-                    General Settings
-                </button>
-            </h2>
-            <div id="generalSettingsCollapse" class="accordion-collapse collapse" aria-labelledby="generalSettingsHeader" data-bs-parent="#clientSettingsAccordion">
-                <div class="accordion-body text-muted">
-                    Additional client settings will be available here.
+                    <div class="col-12">
+                        <label for="notes" class="form-label fw-semibold">Notes</label>
+                        <textarea id="notes" name="notes" rows="4" class="form-control @error('notes') is-invalid @enderror">{{ old('notes', $client->notes) }}</textarea>
+                        @error('notes')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
+
+        <!-- ------------------------------------------------- -->
+        <!-- RMM mapping -->
+        <!-- ------------------------------------------------- -->
+        @if($rmmIntegration && $rmmIntegration->status === 'active')
+            <div class="card mb-3">
+                <div class="card-header">
+                    <h2 class="h5 mb-0">N-able RMM Integration</h2>
+                </div>
+                <div class="card-body">
+                    @if(isset($rmmError))
+                        <div class="alert alert-warning">
+                            <i class="bi bi-exclamation-triangle-fill me-2"></i>
+                            <strong>Warning:</strong> Could not fetch clients from N-able RMM.
+                            <p class="mb-0 small text-muted mt-1">{{ $rmmError }}</p>
+                        </div>
+                    @endif
+
+                    <label for="rmm_external_id" class="form-label">Link to N-able RMM Client</label>
+                    <select name="rmm_external_id" id="rmm_external_id" class="form-select" {{ isset($rmmError) ? 'disabled' : '' }}>
+                        <option value="">-- {{ isset($rmmError) ? 'Error fetching clients' : 'No RMM link' }} --</option>
+                        @foreach($rmmClients as $rmmClient)
+                            <option value="{{ $rmmClient['clientid'] }}" @selected(($currentRmmId ?? '') == $rmmClient['clientid'])>
+                                {{ $rmmClient['name'] }} ({{ $rmmClient['clientid'] }})
+                            </option>
+                        @endforeach
+                    </select>
+                    <div class="form-text">Select the corresponding client in N-able RMM to enable synchronization.</div>
+                </div>
+            </div>
+        @endif
+
+        <!-- ------------------------------------------------- -->
+        <!-- Custom fields -->
+        <!-- ------------------------------------------------- -->
+        @if(($customFields ?? collect())->isNotEmpty())
+            <div class="card mb-3">
+                <div class="card-header">
+                    <h2 class="h5 mb-0">Custom Fields</h2>
+                </div>
+                <div class="card-body">
+                    <div class="row g-3">
+                        @foreach($customFields as $field)
+                            @php($definition = $field['definition'])
+                            <div class="col-md-6">
+                                <label class="form-label" for="customField{{ $definition->id }}">
+                                    {{ $field['label'] }}
+                                    @if($field['required'])
+                                        <span class="text-danger">*</span>
+                                    @endif
+                                </label>
+
+                                @include('customfield::components.value-input', [
+                                    'field' => $field,
+                                    'inputName' => 'custom_fields['.$field['key'].']',
+                                    'inputId' => 'customField'.$definition->id,
+                                ])
+
+                                @error('custom_fields.'.$field['key'])
+                                    <div class="invalid-feedback d-block">{{ $message }}</div>
+                                @enderror
+                                @if($field['help_text'])
+                                    <div class="form-text">{{ $field['help_text'] }}</div>
+                                @endif
+                            </div>
+                        @endforeach
+                    </div>
+                </div>
+            </div>
+        @endif
+
+        <div class="d-flex justify-content-end gap-2 mb-4">
+            <a href="{{ route('tech.clients.show', $client) }}" class="btn btn-outline-secondary">Cancel</a>
+            <button type="submit" class="btn btn-primary">Save Client</button>
+        </div>
+    </form>
 @endsection

--- a/app/Modules/Clients/Views/Tech/index.blade.php
+++ b/app/Modules/Clients/Views/Tech/index.blade.php
@@ -14,10 +14,14 @@
 @section('content')
     @php
         $missing = fn ($value) => filled($value) ? $value : '—';
-        $sortLink = function (string $column) use ($sort, $direction) {
+        $filters = $filters ?? ['search' => $search ?? null];
+        $activeFilterCount = $activeFilterCount ?? 0;
+        $filtersOpen = $activeFilterCount > 0;
+        $sortLink = function (string $column) use ($sort, $direction, $filters) {
             $nextDirection = $sort === $column && $direction === 'asc' ? 'desc' : 'asc';
 
             return request()->fullUrlWithQuery([
+                ...array_filter($filters, fn ($value) => filled($value)),
                 'sort' => $column,
                 'direction' => $nextDirection,
             ]);
@@ -34,18 +38,76 @@
     <!-- ------------------------------------------------- -->
     <!-- Search and list controls -->
     <!-- ------------------------------------------------- -->
-    <form method="get" class="mb-3">
-        <div class="row g-2 align-items-end">
-            <div class="col-md-10">
-                <div class="input-group input-group-sm">
-                    <input type="text" name="search" value="{{ $search }}" class="form-control" placeholder="Search name / org no / email" />
-                    <input type="hidden" name="sort" value="{{ $sort }}">
-                    <input type="hidden" name="direction" value="{{ $direction }}">
-                    <button class="btn btn-outline-secondary" type="submit">Search</button>
+    <form method="get" class="card mb-3">
+        <div class="card-body py-3">
+            <div class="row g-2 align-items-end">
+                <div class="col-md-8 col-lg-9">
+                    <label for="client_search" class="form-label small text-muted mb-1">Search</label>
+                    <div class="input-group input-group-sm">
+                        <input id="client_search" type="text" name="search" value="{{ $filters['search'] ?? '' }}" class="form-control" placeholder="Name, client number, org no, or billing email" />
+                        <input type="hidden" name="sort" value="{{ $sort }}">
+                        <input type="hidden" name="direction" value="{{ $direction }}">
+                        <button class="btn btn-outline-secondary" type="submit">Search</button>
+                    </div>
+                </div>
+                <div class="col-md-4 col-lg-3 d-flex justify-content-md-end gap-2">
+                    <button class="btn btn-sm btn-outline-secondary position-relative" type="button" data-bs-toggle="collapse" data-bs-target="#clientAdvancedFilters" aria-expanded="{{ $filtersOpen ? 'true' : 'false' }}" aria-controls="clientAdvancedFilters" title="Advanced filters">
+                        <i class="bi bi-funnel"></i>
+                        @if($activeFilterCount > 0)
+                            <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill text-bg-primary">{{ $activeFilterCount }}</span>
+                        @endif
+                    </button>
+                    @if($activeFilterCount > 0)
+                        <a href="{{ route('tech.clients.index', ['clear_filters' => 1]) }}" class="btn btn-sm btn-outline-secondary">Clear</a>
+                    @endif
+                    <x-buttons.addlink url="{{ route('tech.clients.create') }}" class="mb-0">New Client</x-buttons.addlink>
                 </div>
             </div>
-            <div class="col-md-2 text-md-end">
-                <x-buttons.addlink url="{{ route('tech.clients.create') }}" class="mb-0">New Client</x-buttons.addlink>
+
+            <div @class(['collapse mt-3', 'show' => $filtersOpen]) id="clientAdvancedFilters">
+                <div class="row g-2">
+                    <div class="col-md-3">
+                        <label for="client_status_filter" class="form-label small text-muted mb-1">Status</label>
+                        <select id="client_status_filter" name="status" class="form-select form-select-sm">
+                            <option value="">All statuses</option>
+                            <option value="active" @selected(($filters['status'] ?? '') === 'active')>Active</option>
+                            <option value="inactive" @selected(($filters['status'] ?? '') === 'inactive')>Inactive</option>
+                        </select>
+                    </div>
+
+                    <div class="col-md-3">
+                        <label for="client_format_filter" class="form-label small text-muted mb-1">Format</label>
+                        <select id="client_format_filter" name="format_id" class="form-select form-select-sm">
+                            <option value="">All formats</option>
+                            @foreach(($clientFormats ?? []) as $format)
+                                <option value="{{ $format->id }}" @selected((string) ($filters['format_id'] ?? '') === (string) $format->id)>{{ $format->code }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+
+                    <div class="col-md-3">
+                        <label for="client_contract_filter" class="form-label small text-muted mb-1">Contracts</label>
+                        <select id="client_contract_filter" name="contract_filter" class="form-select form-select-sm">
+                            <option value="">All contract states</option>
+                            <option value="without_contract" @selected(($filters['contract_filter'] ?? '') === 'without_contract')>Without contract</option>
+                            <option value="with_contract" @selected(($filters['contract_filter'] ?? '') === 'with_contract')>Has contract</option>
+                            <option value="won_contract" @selected(($filters['contract_filter'] ?? '') === 'won_contract')>Won contract</option>
+                        </select>
+                    </div>
+
+                    <div class="col-md-3">
+                        <label for="client_rmm_filter" class="form-label small text-muted mb-1">RMM</label>
+                        <select id="client_rmm_filter" name="rmm_filter" class="form-select form-select-sm" @disabled(! $rmmIntegration)>
+                            <option value="">All RMM states</option>
+                            <option value="linked" @selected(($filters['rmm_filter'] ?? '') === 'linked')>RMM linked</option>
+                            <option value="unlinked" @selected(($filters['rmm_filter'] ?? '') === 'unlinked')>RMM unlinked</option>
+                        </select>
+                    </div>
+
+                    <div class="col-12 d-flex justify-content-end">
+                        <button type="submit" class="btn btn-sm btn-primary">Apply Filters</button>
+                    </div>
+                </div>
             </div>
         </div>
     </form>
@@ -58,6 +120,11 @@
             <table class="table table-sm table-hover align-middle mb-0">
                 <thead class="table-light">
                 <tr>
+                    <th>
+                        <a href="{{ $sortLink('client_number') }}" class="text-decoration-none text-body d-inline-flex align-items-center gap-1">
+                            No <i class="bi {{ $sortIcon('client_number') }}"></i>
+                        </a>
+                    </th>
                     <th>
                         <a href="{{ $sortLink('name') }}" class="text-decoration-none text-body d-inline-flex align-items-center gap-1">
                             Name <i class="bi {{ $sortIcon('name') }}"></i>
@@ -79,6 +146,13 @@
                         </a>
                     </th>
                     <th>Risk Score</th>
+                    <th>Sites</th>
+                    <th>Contacts</th>
+                    <th>
+                        <a href="{{ $sortLink('contracts') }}" class="text-decoration-none text-body d-inline-flex align-items-center gap-1">
+                            Contracts <i class="bi {{ $sortIcon('contracts') }}"></i>
+                        </a>
+                    </th>
                     <th>
                         <a href="{{ $sortLink('status') }}" class="text-decoration-none text-body d-inline-flex align-items-center gap-1">
                             Status <i class="bi {{ $sortIcon('status') }}"></i>
@@ -89,6 +163,7 @@
                 <tbody>
                 @forelse($clients as $client)
                     <tr class="cursor-pointer" data-href="{{ route('tech.clients.show', $client) }}" onclick="window.location.href = this.dataset.href">
+                        <td class="{{ blank($client->client_number) ? 'text-muted' : '' }}">{{ $missing($client->client_number) }}</td>
                         <td>
                             <a href="{{ route('tech.clients.show', $client) }}" class="fw-semibold text-decoration-none" onclick="event.stopPropagation()">
                                 {{ $client->name }}
@@ -112,6 +187,15 @@
                                 <span class="text-muted">—</span>
                             @endif
                         </td>
+                        <td>{{ $client->sites_count }}</td>
+                        <td>{{ $client->contacts_count }}</td>
+                        <td>
+                            @if($client->contracts_count > 0)
+                                <span class="badge text-bg-light border">{{ $client->contracts_count }}</span>
+                            @else
+                                <span class="badge text-bg-warning">No contract</span>
+                            @endif
+                        </td>
                         <td>
                             @if($client->active)
                                 <span class="badge bg-success">Active</span>
@@ -122,7 +206,7 @@
                     </tr>
                 @empty
                     <tr>
-                        <td colspan="6" class="text-center text-muted py-4">No clients found.</td>
+                        <td colspan="10" class="text-center text-muted py-4">No clients found.</td>
                     </tr>
                 @endforelse
                 </tbody>

--- a/app/Modules/Nextcloud/Controllers/Admin/NextcloudConnectionController.php
+++ b/app/Modules/Nextcloud/Controllers/Admin/NextcloudConnectionController.php
@@ -24,8 +24,8 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
 use Illuminate\View\View;
-use Throwable;
 use Spatie\Permission\Models\Role;
+use Throwable;
 
 class NextcloudConnectionController extends Controller
 {
@@ -142,6 +142,38 @@ class NextcloudConnectionController extends Controller
     }
 
     /**
+     * Update Talk Bot configuration only (separate form on show page).
+     */
+    public function updateTalkBot(Request $request, NextcloudConnection $connection): RedirectResponse
+    {
+        $data = $request->validate([
+            'talk_bot_id' => ['nullable', 'integer'],
+            'talk_bot_secret' => ['nullable', 'string', 'max:500'],
+            'talk_default_conversation_token' => ['nullable', 'string', 'max:64'],
+            'talk_bot_features' => ['nullable', 'array'],
+            'talk_bot_features.*' => ['string', Rule::in(['reaction', 'no-setup'])],
+        ]);
+
+        $connection->talk_bot_id = isset($data['talk_bot_id']) && $data['talk_bot_id'] !== ''
+            ? (int) $data['talk_bot_id']
+            : null;
+
+        if (! empty($data['talk_bot_secret']) && $data['talk_bot_secret'] !== str_repeat('•', 8)) {
+            $connection->talk_bot_secret = $data['talk_bot_secret'];
+        }
+
+        $connection->talk_default_conversation_token = ($data['talk_default_conversation_token'] ?? '') !== ''
+            ? $data['talk_default_conversation_token']
+            : null;
+        $connection->talk_bot_features = $data['talk_bot_features'] ?? [];
+        $connection->save();
+
+        return redirect()
+            ->route('tech.admin.nextcloud.connections.show', $connection)
+            ->with('success', 'Talk Bot settings saved.');
+    }
+
+    /**
      * Send a test message via the Talk Bot API.
      */
     public function testTalkBot(NextcloudConnection $connection)
@@ -162,7 +194,7 @@ class NextcloudConnectionController extends Controller
                 $connection,
                 $conversationToken,
                 '🔔 Test message from Nexum — Talk bot integration is working!',
-                ['referenceId' => 'nexum-test-' . time()]
+                ['referenceId' => 'nexum-test-'.time()]
             );
 
             return response()->json(['success' => true]);
@@ -198,7 +230,7 @@ class NextcloudConnectionController extends Controller
             'remote_user_id' => ['required', 'string', 'max:255'],
             'remote_username' => ['nullable', 'string', 'max:255'],
             'remote_email' => ['nullable', 'email', 'max:255'],
-            'user_id' => ['nullable', 'integer', 'exists:'.(new User())->getTable().',id'],
+            'user_id' => ['nullable', 'integer', 'exists:'.(new User)->getTable().',id'],
             'client_user_id' => ['nullable', 'integer', 'exists:client_users,id'],
             'identity_type' => ['required', Rule::in(['technician', 'client_contact', 'portal_user', 'external'])],
         ]);
@@ -332,12 +364,12 @@ class NextcloudConnectionController extends Controller
                 : null;
 
             $clientUser ??= ClientUser::query()->create([
-                    'client_site_id' => $site->id,
-                    'name' => $data['remote_username'] ?: $data['remote_user_id'],
-                    'email' => $email,
-                    'role' => $clientRole,
-                    'active' => true,
-                ]);
+                'client_site_id' => $site->id,
+                'name' => $data['remote_username'] ?: $data['remote_user_id'],
+                'email' => $email,
+                'role' => $clientRole,
+                'active' => true,
+            ]);
 
             if ($clientUser->role !== $clientRole) {
                 $clientUser->forceFill(['role' => $clientRole])->save();
@@ -378,7 +410,7 @@ class NextcloudConnectionController extends Controller
             'remote_calendar_id' => ['required', 'string', 'max:500'],
             'remote_display_name' => ['nullable', 'string', 'max:255'],
             'calendar_id' => ['nullable', 'integer', 'exists:calendars,id'],
-            'user_id' => ['nullable', 'integer', 'exists:'.(new User())->getTable().',id'],
+            'user_id' => ['nullable', 'integer', 'exists:'.(new User)->getTable().',id'],
             'sync_direction' => ['required', Rule::in(['two_way', 'pull_only', 'push_only'])],
         ]);
 

--- a/app/Modules/Nextcloud/Views/Admin/connections/show.blade.php
+++ b/app/Modules/Nextcloud/Views/Admin/connections/show.blade.php
@@ -624,7 +624,7 @@
                     <code>./occ talk:bot:install "Nexum Bot" &lt;secret&gt; &lt;webhook-url&gt; &lt;nextcloud-url&gt;</code>
                 </div>
 
-                <form method="POST" action="{{ route('tech.admin.nextcloud.connections.update', $connection) }}">
+                <form method="POST" action="{{ route('tech.admin.nextcloud.connections.update-talk-bot', $connection) }}">
                     @csrf
                     @method('PATCH')
 

--- a/app/Modules/Nextcloud/routes.php
+++ b/app/Modules/Nextcloud/routes.php
@@ -38,6 +38,9 @@ Route::middleware('admin')->group(function () {
     Route::post('/admin/system/nextcloud/connections/{connection}/test-talk-bot', [NextcloudConnectionController::class, 'testTalkBot'])
         ->name('admin.nextcloud.connections.test-talk-bot');
 
+    Route::patch('/admin/system/nextcloud/connections/{connection}/talk-bot', [NextcloudConnectionController::class, 'updateTalkBot'])
+        ->name('admin.nextcloud.connections.update-talk-bot');
+
     Route::post('/admin/system/nextcloud/connections/{connection}/users', [NextcloudConnectionController::class, 'storeUserMapping'])
         ->name('admin.nextcloud.connections.users.store');
 

--- a/docs/rfc/2026-06-05-client-deletion-retention-policy.md
+++ b/docs/rfc/2026-06-05-client-deletion-retention-policy.md
@@ -1,0 +1,164 @@
+# RFC: Client Deletion And Retention Policy
+
+Status: Draft
+Date: 2026-06-05
+Owner: Codex
+
+## Context
+
+Production import work is creating Clients, Sites, and Contacts quickly. Technicians need a way to
+remove obvious unwanted Clients from the Client edit view, especially contractless Clients created
+during import cleanup.
+
+Deleting Clients is a data-retention decision, not only a UI action. Clients can be referenced by
+Tickets, Tasks, Contacts, Sites, Assets, Contracts, Risk, Documentation, integrations, and future
+reporting. Some Clients should only be deactivated, some can be archived through soft delete, and a
+small subset can be physically deleted when they have no important history.
+
+The current `Client` model does not use `SoftDeletes`.
+
+## Goals
+
+- Add a clear Client removal action from the Client edit/settings view.
+- Prevent accidental loss of historical Client records.
+- Keep Clients with work history for at least the configured retention period.
+- Make retention and hard-delete behavior configurable from settings.
+- Show technicians why a Client cannot be deleted and what safer action is available.
+- Support production import cleanup without forcing database surgery.
+
+## Non-Goals
+
+- Bulk deletion of Clients.
+- Restoring archived Clients from a dedicated recycle-bin UI in the first slice.
+- Deleting linked Tickets, Tasks, Contracts, Assets, Contacts, Sites, or integration records as part
+  of the first implementation.
+- Changing API deletion behavior before the UI policy is proven.
+
+## Current Behavior
+
+- Client edit/settings can update core Client details, status, RMM mapping, and Custom Fields.
+- Client index can filter Clients without contracts.
+- There is no Client delete/archive route.
+- `Client` does not currently use `SoftDeletes`.
+- `client.delete` permission exists in the permission map, but no Client delete workflow is
+  implemented.
+
+## Proposed Change
+
+Implement a settings-backed Client removal policy.
+
+Default policy:
+
+- `minimum_retention_years`: `3`
+- `allow_soft_delete`: `true`
+- `allow_hard_delete`: `false`
+- `hard_delete_import_only`: `true`
+- `block_active_contracts`: `true`
+- `block_open_tickets`: `true`
+- `block_open_tasks`: `true`
+- `block_recent_ticket_history`: `true`
+- `recent_ticket_retention_years`: `3`
+
+Removal behavior:
+
+1. The Client edit view shows a `Danger Zone` card only to users allowed by `client.delete`.
+2. If the Client has any active/won/sent Contract, open Ticket, open Task, or Ticket newer than the
+   configured retention period, the UI offers `Deactivate Client` and explains what blocks deletion.
+3. If policy allows soft delete and the Client has no blocking records, the UI offers
+   `Archive Client`.
+4. If policy allows hard delete and the Client has no blocking records and no important history, the
+   UI offers `Delete Permanently`.
+5. `Delete Permanently` is off by default and should be used only for import cleanup or clearly
+   disposable Clients.
+
+Recommended first slice:
+
+- Add `SoftDeletes` to `clients`.
+- Add `ClientRemovalPolicy` support class.
+- Add Client removal settings in Client/Admin settings.
+- Add deactivate/archive actions to Client edit view.
+- Do not implement hard delete until soft-delete behavior is validated in production.
+
+## Impact Analysis
+
+Affected modules:
+
+- Clients: model, edit view, controller/routes, Knowledge docs, tests.
+- Commercial: Contract references block deletion.
+- Ticket: open and recent Tickets block deletion.
+- Task: open Tasks block deletion.
+- Contact/Site/Asset/Integration: referenced data must be preserved when a Client is archived.
+
+Permissions:
+
+- Use existing `client.delete` for archive/delete actions.
+- Deactivation remains part of Client edit/update for users who can edit Clients.
+
+Routes:
+
+- Add Client-owned routes under `app/Modules/Clients/routes.php`, for example:
+  - `PATCH /tech/clients/{client}/deactivate`
+  - `DELETE /tech/clients/{client}/archive`
+  - optional later: `DELETE /tech/clients/{client}/force-delete`
+
+Data:
+
+- Add nullable `deleted_at` to `clients`.
+- Existing foreign keys and references remain intact.
+- Hard delete must be blocked when child/reference records exist unless a future RFC explicitly
+  approves cascading behavior.
+
+Integrations:
+
+- RMM links should be retained on soft-deleted Clients.
+- API list endpoints should continue to exclude soft-deleted Clients by default.
+
+Queues:
+
+- No queue changes expected.
+
+UI:
+
+- Client edit/settings gets a `Danger Zone` card.
+- Client index should not show archived Clients by default. A later filter can expose archived
+  Clients if restore UI is implemented.
+
+Docs:
+
+- Update Client Knowledge documentation with deactivate/archive/delete rules.
+
+## Data And Migration Plan
+
+- Migration: add `deleted_at` to `clients`.
+- Model: add `SoftDeletes` to `App\Models\Clients\Client`.
+- No destructive data migration.
+- Rollback: remove `deleted_at` only if no archived Clients exist, or restore archived rows before
+  rollback.
+- Deploy order: code and migration can deploy together. Run `php artisan migrate --force`.
+
+## Testing Plan
+
+- Feature test: Client edit shows `Danger Zone` for delete-capable users.
+- Feature test: contractless Client with no work history can be archived.
+- Feature test: active/won Contract blocks archive/hard delete.
+- Feature test: open Ticket blocks archive/hard delete.
+- Feature test: Ticket newer than retention period blocks hard delete.
+- Feature test: open Task blocks archive/hard delete.
+- Feature test: deactivation remains available when deletion is blocked.
+- Feature test: archived Clients disappear from default Client index.
+- Unit/service tests for `ClientRemovalPolicy` blocker reasons.
+
+## Documentation Plan
+
+- Update `app/Modules/Clients/Docs/knowledge/client-domain-overview.md`.
+- Add deploy note that this introduces a Client soft-delete migration.
+- Add Client retention policy to admin/settings documentation if a general settings page is added.
+
+## Open Questions
+
+Should the first implementation include hard delete at all, or should first slice ship only
+Deactivate + Archive with hard delete documented as a later, explicitly enabled slice?
+
+## Approval
+
+Pending approval by Svein.


### PR DESCRIPTION
The Talk Bot configuration form on the connection show page was posting to the general update endpoint, which requires all connection fields (name, scope, mode, base_url, sync_interval_minutes) — causing a validation error when only Talk bot fields were submitted.

- Add updateTalkBot() method with Talk-specific validation only (talk_bot_id, talk_bot_secret, talk_default_conversation_token, talk_bot_features)
- Add PATCH route connections/{connection}/talk-bot
- Update Talk Bot form to use the new dedicated route
- All 9 TalkWebhookTest cases pass