### PR TITLE
fix(nextcloud-talk): correct Bot API header names and signature payload

### DIFF
--- a/app/Modules/Clients/Controllers/Tech/ClientController.php
+++ b/app/Modules/Clients/Controllers/Tech/ClientController.php
@@ -179,6 +179,7 @@ class ClientController extends Controller
         // Client Contract (s)
         // -----------------------------------------
         $contracts = $client->contracts()->with('items')->latest('updated_at')->get();
+        $contacts = $client->contacts()->with('site')->orderBy('client_users.name')->get();
 
         // -----------------------------------------
         // Eager load risk assessments and items
@@ -226,6 +227,7 @@ class ClientController extends Controller
             'client' => $client,
             'sidebarMenuItems' => $sidebarMenuItems,
             'contracts' => $contracts,
+            'contacts' => $contacts,
             'technicians' => User::query()->where('status', User::STATUS_ACTIVE)->orderBy('name')->get(),
             'clientTasks' => $clientTasks,
             'customFields' => $customFields->visibleFor($client, $request->user()),

--- a/app/Modules/Clients/Docs/knowledge/client-domain-overview.md
+++ b/app/Modules/Clients/Docs/knowledge/client-domain-overview.md
@@ -19,6 +19,11 @@ The Client show page uses the gear action in the Summary card as the Client edit
 This edit surface updates core Client fields, Client status, the N-able RMM mapping, and editable
 Client custom field values.
 
+The Client show page also has workspace tabs for related records. `Sites` shows the Client's
+locations, while `Contacts` shows all Client contacts across all Sites so technicians can verify
+whether a Client has contacts without opening each Site first. The Contacts tab links to the
+existing Client contact detail and create flows.
+
 The Client index has a compact search row and an advanced filter panel behind the funnel icon.
 Technicians can filter by active status, Client format, contract presence, won contracts, and RMM
 link state when RMM is configured. Client index filters are remembered in the technician session for

--- a/app/Modules/Clients/Tests/Feature/ClientTechTest.php
+++ b/app/Modules/Clients/Tests/Feature/ClientTechTest.php
@@ -219,6 +219,15 @@ class ClientTechTest extends TestCase
             'client_id' => $client->id,
             'name' => 'Main Office',
         ]);
+        $contact = ClientUser::factory()->create([
+            'client_site_id' => $site->id,
+            'name' => 'Primary Client Contact',
+            'email' => 'primary.contact@example.test',
+            'phone' => '+47 900 00 001',
+            'role' => 'IT contact',
+            'is_default_for_client' => true,
+            'active' => true,
+        ]);
         $task = app(StoreTask::class)->handle([
             'title' => 'Review client backup',
         ], $this->techUser, $client);
@@ -253,11 +262,17 @@ class ClientTechTest extends TestCase
         $response->assertSee('clientWorkspaceTabs', false);
         $response->assertSee('data-bs-target="#client-assets-pane"', false);
         $response->assertSee('data-bs-target="#client-sites-pane"', false);
+        $response->assertSee('data-bs-target="#client-contacts-pane"', false);
         $response->assertSee('data-bs-target="#client-contracts-pane"', false);
         $response->assertSee('data-bs-target="#client-tasks-pane"', false);
         $response->assertSee('nav nav-tabs border-bottom border-secondary-subtle', false);
         $response->assertSee('nav-link active text-body border border-bottom-0', false);
         $response->assertSee('Main Office');
+        $response->assertSee('Primary Client Contact');
+        $response->assertSee('primary.contact@example.test');
+        $response->assertSee('IT contact');
+        $response->assertSee(route('tech.clients.user.show', $contact), false);
+        $response->assertSee(route('tech.clients.user.create', $client), false);
         $response->assertSee('Review client backup');
         $response->assertSee('Ticket task visible on client');
         $response->assertSee('clientTaskQuickCreateModal', false);
@@ -265,6 +280,12 @@ class ClientTechTest extends TestCase
         $response->assertDontSee('Client Sites');
         $response->assertDontSee('Back to Clients');
         $this->assertEquals($client->id, session('active_client_id'));
+
+        $this->actingAs($this->techUser)
+            ->get(route('tech.clients.show', ['client' => $client, 'tab' => 'contacts']))
+            ->assertOk()
+            ->assertSee('id="client-contacts-pane"', false)
+            ->assertSee('show active', false);
     }
 
     #[Test]

--- a/app/Modules/Clients/Views/Tech/show.blade.php
+++ b/app/Modules/Clients/Views/Tech/show.blade.php
@@ -18,7 +18,8 @@
     @php
         $clientTasks = $clientTasks->sortByDesc('updated_at')->values();
         $missing = fn ($value) => filled($value) ? $value : '—';
-        $availableTabs = ['assets', 'sites', 'contracts', 'tasks', 'custom-fields'];
+        $contacts = ($contacts ?? collect())->sortBy('name')->values();
+        $availableTabs = ['assets', 'sites', 'contacts', 'contracts', 'tasks', 'custom-fields'];
         $activeClientTab = in_array(request('tab'), $availableTabs, true) ? request('tab') : 'assets';
         if ($activeClientTab === 'custom-fields' && ($customFields ?? collect())->isEmpty()) {
             $activeClientTab = 'assets';
@@ -94,6 +95,11 @@
                     </button>
                 </li>
                 <li class="nav-item" role="presentation">
+                    <button class="nav-link {{ $activeClientTab === 'contacts' ? 'active ' : '' }}text-body border border-bottom-0" id="client-contacts-tab" data-bs-toggle="tab" data-bs-target="#client-contacts-pane" type="button" role="tab" aria-controls="client-contacts-pane" aria-selected="{{ $activeClientTab === 'contacts' ? 'true' : 'false' }}">
+                        Contacts <span class="badge text-bg-light border ms-1">{{ $contacts->count() }}</span>
+                    </button>
+                </li>
+                <li class="nav-item" role="presentation">
                     <button class="nav-link {{ $activeClientTab === 'contracts' ? 'active ' : '' }}text-body border border-bottom-0" id="client-contracts-tab" data-bs-toggle="tab" data-bs-target="#client-contracts-pane" type="button" role="tab" aria-controls="client-contracts-pane" aria-selected="{{ $activeClientTab === 'contracts' ? 'true' : 'false' }}">
                         Contracts <span class="badge text-bg-light border ms-1">{{ $contracts->count() }}</span>
                     </button>
@@ -151,6 +157,81 @@
                                     @empty
                                         <tr>
                                             <td colspan="4" class="text-center text-muted py-4">No sites registered for this client.</td>
+                                        </tr>
+                                    @endforelse
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+
+                <div @class(['tab-pane fade', 'show active' => $activeClientTab === 'contacts']) id="client-contacts-pane" role="tabpanel" aria-labelledby="client-contacts-tab" tabindex="0">
+                    <div class="card mb-4">
+                        <div class="card-header d-flex justify-content-between align-items-center">
+                            <div class="d-flex align-items-center gap-2">
+                                <span class="fw-semibold">Contacts</span>
+                                <span class="badge text-bg-light border">{{ $contacts->count() }}</span>
+                            </div>
+                            <x-buttons.addlink url="{{ route('tech.clients.user.create', $client) }}" class="mb-0">New Contact</x-buttons.addlink>
+                        </div>
+                        <div class="table-responsive">
+                            <table class="table table-sm table-hover align-middle mb-0">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th>Name</th>
+                                        <th>Site</th>
+                                        <th>Role</th>
+                                        <th>Email</th>
+                                        <th>Phone</th>
+                                        <th>Status</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @forelse($contacts as $contact)
+                                        <tr class="cursor-pointer" data-href="{{ route('tech.clients.user.show', $contact) }}" onclick="window.location.href = this.dataset.href">
+                                            <td>
+                                                <a href="{{ route('tech.clients.user.show', $contact) }}" class="fw-semibold text-decoration-none" onclick="event.stopPropagation()">
+                                                    {{ $contact->name }}
+                                                </a>
+                                                @if($contact->is_default_for_client)
+                                                    <span class="badge text-bg-light border ms-1">Default</span>
+                                                @endif
+                                            </td>
+                                            <td>
+                                                @if($contact->site)
+                                                    <a href="{{ route('tech.clients.sites.show', $contact->site) }}" class="text-decoration-none" onclick="event.stopPropagation()">
+                                                        {{ $contact->site->name }}
+                                                    </a>
+                                                @else
+                                                    <span class="text-muted">—</span>
+                                                @endif
+                                            </td>
+                                            <td class="{{ blank($contact->role) ? 'text-muted' : '' }}">{{ $missing($contact->role) }}</td>
+                                            <td class="{{ blank($contact->email) ? 'text-muted' : '' }}">
+                                                @if(filled($contact->email))
+                                                    <a href="mailto:{{ $contact->email }}" onclick="event.stopPropagation()">{{ $contact->email }}</a>
+                                                @else
+                                                    —
+                                                @endif
+                                            </td>
+                                            <td class="{{ blank($contact->phone) ? 'text-muted' : '' }}">
+                                                @if(filled($contact->phone))
+                                                    <a href="tel:{{ $contact->phone }}" onclick="event.stopPropagation()">{{ $contact->phone }}</a>
+                                                @else
+                                                    —
+                                                @endif
+                                            </td>
+                                            <td>
+                                                @if($contact->active)
+                                                    <span class="badge bg-success">Active</span>
+                                                @else
+                                                    <span class="badge bg-secondary">Inactive</span>
+                                                @endif
+                                            </td>
+                                        </tr>
+                                    @empty
+                                        <tr>
+                                            <td colspan="6" class="text-center text-muted py-4">No contacts registered for this client.</td>
                                         </tr>
                                     @endforelse
                                 </tbody>

--- a/app/Modules/Commercial/Controllers/Tech/Costs/CostController.php
+++ b/app/Modules/Commercial/Controllers/Tech/Costs/CostController.php
@@ -108,7 +108,7 @@ class CostController extends Controller
             'unitId' => $data['unitId'],
             'recurrence' => $data['recurrence'],
             'vendor_id' => $data['vendor_id'],
-            'note' => $data['note'],
+            'note' => $data['note'] ?? '',
             'created_by_user_id' => auth()->id(),
             'updated_by_user_id' => auth()->id(),
         ]);
@@ -146,7 +146,7 @@ class CostController extends Controller
             'unitId' => $data['unitId'],
             'recurrence' => $data['recurrence'],
             'vendor_id' => $data['vendor_id'],
-            'note' => $data['note'],
+            'note' => $data['note'] ?? '',
             'updated_by_user_id' => auth()->id(),
         ]);
 

--- a/app/Modules/Commercial/Docs/knowledge/cost-catalogue.md
+++ b/app/Modules/Commercial/Docs/knowledge/cost-catalogue.md
@@ -22,4 +22,5 @@ Rows are clickable and open the cost detail view. The cost name remains a direct
 
 - Cost values should be entered excluding VAT unless the finance workflow explicitly states otherwise.
 - Recurrence should match the vendor billing rhythm as closely as possible.
+- Vendors are shared master data owned by Documentation. Use `New vendor` on the Cost form when the needed vendor is not already available in the selector.
 - Costs attached to services influence profitability calculations, so update them when vendor pricing changes.

--- a/app/Modules/Commercial/Requests/ServiceStoreRequest.php
+++ b/app/Modules/Commercial/Requests/ServiceStoreRequest.php
@@ -12,6 +12,29 @@ class ServiceStoreRequest extends FormRequest
         return auth()->check();
     }
 
+    protected function prepareForValidation(): void
+    {
+        if (! $this->has('timebank_minutes')) {
+            return;
+        }
+
+        $minutes = $this->input('timebank_minutes');
+
+        if ($minutes === '' || $minutes === null) {
+            $this->merge(['timebank_minutes' => null]);
+
+            return;
+        }
+
+        $normalized = is_string($minutes)
+            ? str_replace(',', '.', $minutes)
+            : $minutes;
+
+        if (is_numeric($normalized)) {
+            $this->merge(['timebank_minutes' => (string) (int) $normalized]);
+        }
+    }
+
     public function rules(): array
     {
         return [

--- a/app/Modules/Commercial/Tests/Feature/CommercialModuleTest.php
+++ b/app/Modules/Commercial/Tests/Feature/CommercialModuleTest.php
@@ -477,6 +477,77 @@ class CommercialModuleTest extends TestCase
     }
 
     #[Test]
+    public function service_edit_shows_timebank_minutes_as_integer(): void
+    {
+        $unit = Units::query()->create(['name' => 'Hour', 'short' => 'h']);
+        $service = Services::query()->create([
+            'sku' => 'TIMEBANK-PLAN',
+            'name' => 'Timebank plan',
+            'unitId' => $unit->id,
+            'status' => 'Active',
+            'taxable' => 25,
+            'billing_cycle' => 'monthly',
+            'price_ex_vat' => 1000,
+            'price_including_tax' => 1250,
+            'timebank_enabled' => true,
+            'timebank_minutes' => 60,
+            'timebank_interval' => 'monthly',
+            'created_by_user_id' => $this->tech->id,
+            'updated_by_user_id' => $this->tech->id,
+        ]);
+
+        $this->actingAs($this->tech)
+            ->get(route('tech.services.edit', $service))
+            ->assertOk()
+            ->assertSee('name="timebank_minutes"', false)
+            ->assertSee('value="60"', false)
+            ->assertDontSee('value="60.00"', false)
+            ->assertDontSee('value="60,00"', false);
+    }
+
+    #[Test]
+    public function service_update_accepts_decimal_formatted_timebank_minutes(): void
+    {
+        $unit = Units::query()->create(['name' => 'Hour', 'short' => 'h']);
+        $service = Services::query()->create([
+            'sku' => 'TIMEBANK-SAVE',
+            'name' => 'Timebank save',
+            'unitId' => $unit->id,
+            'status' => 'draft',
+            'taxable' => 25,
+            'billing_cycle' => 'monthly',
+            'price_ex_vat' => 1000,
+            'price_including_tax' => 1250,
+            'timebank_enabled' => true,
+            'timebank_minutes' => 30,
+            'timebank_interval' => 'monthly',
+            'created_by_user_id' => $this->tech->id,
+            'updated_by_user_id' => $this->tech->id,
+        ]);
+
+        $this->actingAs($this->tech)
+            ->post(route('tech.services.update', $service), [
+                'sku' => 'TIMEBANK-SAVE',
+                'name' => 'Timebank save',
+                'unitId' => $unit->id,
+                'status' => 'draft',
+                'taxable' => 25,
+                'billing_cycle' => 'monthly',
+                'price_ex_vat' => 1000,
+                'price_including_tax' => 1250,
+                'timebank_enabled' => 1,
+                'timebank_minutes' => '60,00',
+                'timebank_interval' => 'monthly',
+            ])
+            ->assertRedirect(route('tech.services.show', $service));
+
+        $this->assertDatabaseHas('services', [
+            'id' => $service->id,
+            'timebank_minutes' => 60,
+        ]);
+    }
+
+    #[Test]
     public function cost_index_can_search_filter_and_sort_costs(): void
     {
         $unit = Units::query()->create(['name' => 'Month', 'short' => 'mo']);
@@ -539,6 +610,46 @@ class CommercialModuleTest extends TestCase
             ['Endpoint license'],
             $recurrenceResponse->viewData('costs')->getCollection()->pluck('name')->all()
         );
+    }
+
+    #[Test]
+    public function cost_form_links_to_vendor_creation(): void
+    {
+        Units::query()->create(['name' => 'Month', 'short' => 'mo']);
+
+        $this->actingAs($this->tech)
+            ->get(route('tech.costs.create'))
+            ->assertOk()
+            ->assertViewIs('commercial::Tech.cs.costs.form')
+            ->assertSee('Vendor')
+            ->assertSee('New vendor')
+            ->assertSee(route('tech.documentations.vendors.create'), false)
+            ->assertSee('target="_blank"', false);
+    }
+
+    #[Test]
+    public function cost_can_be_created_without_note(): void
+    {
+        $unit = Units::query()->create(['name' => 'Lisens', 'short' => 'lic']);
+        $vendor = Vendor::query()->create(['name' => 'Microsoft']);
+
+        $this->actingAs($this->tech)
+            ->post(route('tech.costs.store'), [
+                'name' => 'Exchange Online (Plan1)',
+                'cost' => 48,
+                'unitId' => $unit->id,
+                'recurrence' => 'month',
+                'vendor_id' => $vendor->id,
+            ])
+            ->assertRedirect(route('tech.costs.index'));
+
+        $this->assertDatabaseHas('costs', [
+            'name' => 'Exchange Online (Plan1)',
+            'cost' => 48,
+            'unitId' => $unit->id,
+            'vendor_id' => $vendor->id,
+            'note' => '',
+        ]);
     }
 
     #[Test]
@@ -855,6 +966,50 @@ class CommercialModuleTest extends TestCase
             ->assertSee('Third-party email SLA')
             ->assertSee('Time with contract')
             ->assertSee('550,00');
+    }
+
+    #[Test]
+    public function contract_item_service_selection_populates_unit_price_field(): void
+    {
+        $client = Client::factory()->create();
+        $unit = Units::query()->create(['name' => 'License', 'short' => 'lic']);
+        $service = Services::query()->create([
+            'sku' => 'EXCHANGE-P1',
+            'name' => 'Exchange Online (Plan1)',
+            'unitId' => $unit->id,
+            'status' => 'published',
+            'orderable' => true,
+            'taxable' => 0,
+            'billing_cycle' => 'monthly',
+            'price_ex_vat' => 48,
+            'price_including_tax' => 48,
+            'created_by_user_id' => $this->tech->id,
+            'updated_by_user_id' => $this->tech->id,
+        ]);
+        $contract = Contracts::query()->create([
+            'client_id' => $client->id,
+            'description' => 'Contract with auto priced line.',
+            'start_date' => now()->addMonth()->toDateString(),
+            'end_date' => now()->addYear()->toDateString(),
+            'binding_end_date' => now()->addYear()->toDateString(),
+            'auto_renew' => true,
+            'renewal_months' => 12,
+            'approval_status' => 'draft',
+            'created_by' => $this->tech->id,
+        ]);
+
+        Livewire::actingAs($this->tech)
+            ->test(ContractItemsEditor::class, ['contract' => $contract])
+            ->call('addItem')
+            ->set('items.0.service_id', $service->id)
+            ->assertSet('items.0.unit_price', '48.00')
+            ->assertSee('48,00 kr');
+
+        $this->assertDatabaseHas('contract_items', [
+            'contract_id' => $contract->id,
+            'service_id' => $service->id,
+            'unit_price' => 48,
+        ]);
     }
 
     #[Test]

--- a/app/Modules/Commercial/Views/Livewire/Tech/Contract/contract-items-editor.blade.php
+++ b/app/Modules/Commercial/Views/Livewire/Tech/Contract/contract-items-editor.blade.php
@@ -4,7 +4,7 @@
         <!-- ------------------------------------------------- -->
         <!-- Top level row -->
         <!-- ------------------------------------------------- -->
-        <div class="row border-bottom mb-3 pb-3">
+        <div class="row border-bottom mb-3 pb-3" wire:key="contract-item-row-{{ $item['id'] ?? 'new-'.$index }}-service-{{ $item['service_id'] ?? 'none' }}">
 
             <!-- ------------------------------------------------- -->
             <!-- Top item level row -->

--- a/app/Modules/Commercial/Views/Tech/cs/costs/form.blade.php
+++ b/app/Modules/Commercial/Views/Tech/cs/costs/form.blade.php
@@ -71,17 +71,20 @@
                     <!-- Vendor -->
                     <div class="col-md-2 mb-3">
                         <x-forms.select name="vendor_id" labelName="Vendor">
-                        @if(isset($cost) && $cost->vendor)
-                            <option value="{{ $cost->vendor->id }}">{{ $cost->vendor->name }}</option>
-                        @else
-                            <option value="" disabled selected>Select vendor</option>
-                        @endif
+                            @if(isset($cost) && $cost->vendor)
+                                <option value="{{ $cost->vendor->id }}">{{ $cost->vendor->name }}</option>
+                            @else
+                                <option value="" disabled selected>Select vendor</option>
+                            @endif
 
-                        @foreach($vendors ?? [] as $vendor)
-                            <option value="{{ $vendor->id }}">{{ $vendor->name }}</option>
-                        @endforeach
-                    </x-forms.select>
+                            @foreach($vendors ?? [] as $vendor)
+                                <option value="{{ $vendor->id }}">{{ $vendor->name }}</option>
+                            @endforeach
+                        </x-forms.select>
 
+                        <div class="form-text">
+                            <a href="{{ route('tech.documentations.vendors.create') }}" target="_blank" rel="noopener">New vendor</a>
+                        </div>
                     </div>
 
                     <div class="col-12">

--- a/app/Modules/Commercial/Views/Tech/partials/forms/create-service-form.blade.php
+++ b/app/Modules/Commercial/Views/Tech/partials/forms/create-service-form.blade.php
@@ -1,6 +1,13 @@
 <!-- ------------------------------------------------- -->
 <!-- Form to create a new service -->
 <!-- ------------------------------------------------- -->
+@php
+    $timebankMinutesValue = old('timebank_minutes', $service->timebank_minutes ?? '');
+    $timebankMinutesValue = $timebankMinutesValue === '' || $timebankMinutesValue === null
+        ? ''
+        : (string) (int) str_replace(',', '.', (string) $timebankMinutesValue);
+@endphp
+
 <x-forms.form-default action="{{ route('tech.services.' . $formRoute, $service) }}" buttonText="{{ $buttonText }}" method="{{$method}}">
 
     <!-- ------------------------------------------------- -->
@@ -275,7 +282,7 @@
 
             <!-- timebank_minutes -->
             <div class="col-md-3 mb-3">
-                <x-forms.input_text name='timebank_minutes' labelName='Timebank Minutes' type='number' value="{{ old('timebank_minutes', $service->timebank_minutes ?? '') }}" enabled="{{ $enabled }}" errorMsg="{{ $message ?? '' }}"></x-forms.input_text>
+                <x-forms.input_text name='timebank_minutes' labelName='Timebank Minutes' type='number' :value="$timebankMinutesValue" enabled="{{ $enabled }}" errorMsg="{{ $message ?? '' }}"></x-forms.input_text>
             </div>
 
             <!-- timebank_interval -->

--- a/app/Modules/Nextcloud/Controllers/TalkWebhookController.php
+++ b/app/Modules/Nextcloud/Controllers/TalkWebhookController.php
@@ -18,9 +18,11 @@ use Illuminate\Support\Facades\Log;
  * message to a bot in a Talk conversation.
  *
  * The route is unauthenticated (no Laravel auth middleware) because Nextcloud
+ * The route is unauthenticated (no Laravel auth middleware) because Nextcloud
  * calls it as an external webhook. Request legitimacy is verified via
  * HMAC-SHA256 signature in the X-Nextcloud-Talk-Signature and
- * X-Nextcloud-Talk-Random headers.
+ * X-Nextcloud-Talk-Random headers (note: no "Bot-" prefix — that prefix
+ * is only for bot-to-Nextcloud requests, not for Nextcloud-to-webhook).
  *
  * @see https://nextcloud-talk.readthedocs.io/en/latest/bots/
  */
@@ -32,6 +34,7 @@ class TalkWebhookController extends Controller
      * Expected headers:
      *   - X-Nextcloud-Talk-Signature: HMAC-SHA256 signature of (random + body)
      *   - X-Nextcloud-Talk-Random:  Random value used in the signature
+     * (Inbound webhooks from Nextcloud use headers WITHOUT the "Bot-" prefix)
      *
      * Expected body: Activity Streams 2.0 JSON from Nextcloud Talk bots.
      */

--- a/app/Modules/Nextcloud/Services/NextcloudTalkClient.php
+++ b/app/Modules/Nextcloud/Services/NextcloudTalkClient.php
@@ -33,9 +33,9 @@ class NextcloudTalkClient
      * @param  string  $conversationToken  The Talk conversation token (e.g., "n3xtc10ud")
      * @param  string  $message  The message text (supports Markdown if the bot has the feature)
      * @param  array  $options  Optional: referenceId, silent, replyTo
-     * @return array  Response data from the Talk API
+     * @return array Response data from the Talk API
      *
-     * @throws RuntimeException  If the request fails
+     * @throws RuntimeException If the request fails
      */
     public function sendBotMessage(NextcloudConnection $connection, string $conversationToken, string $message, array $options = []): array
     {
@@ -59,7 +59,7 @@ class NextcloudTalkClient
             $body['referenceId'] = $options['referenceId'];
         }
 
-        if (!empty($options['silent'])) {
+        if (! empty($options['silent'])) {
             $body['silent'] = true;
         }
 
@@ -67,18 +67,18 @@ class NextcloudTalkClient
             $body['replyTo'] = $options['replyTo'];
         }
 
-        $jsonBody = json_encode($body, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
-
-        // Generate HMAC-SHA256 signature
+        // Generate HMAC-SHA256 signature.
+        // Talk Bot API signs over random + plain message text (not the JSON body).
+        // @see https://nextcloud-talk.readthedocs.io/en/latest/bots/#sending-a-chat-message
         $random = $this->generateRandomString(64);
-        $signature = hash_hmac('sha256', $random . $jsonBody, $secret);
+        $signature = hash_hmac('sha256', $random.$message, $secret);
 
         $response = Http::withHeaders([
             'Accept' => 'application/json',
             'Content-Type' => 'application/json',
             'OCS-APIRequest' => 'true',
-            'X-Nextcloud-Talk-Signature' => strtolower($signature),
-            'X-Nextcloud-Talk-Random' => $random,
+            'X-Nextcloud-Talk-Bot-Signature' => strtolower($signature),
+            'X-Nextcloud-Talk-Bot-Random' => $random,
         ])
             ->timeout(15)
             ->post("{$baseUrl}{$endpoint}", $body);
@@ -98,7 +98,7 @@ class NextcloudTalkClient
      * @param  string  $conversationToken  The Talk conversation token
      * @param  string  $message  The message text
      * @param  array  $options  Optional: referenceId, replyTo, silent, object
-     * @return array  Response data from the Talk API
+     * @return array Response data from the Talk API
      */
     public function sendChatMessage(NextcloudConnection $connection, string $conversationToken, string $message, array $options = []): array
     {
@@ -115,7 +115,7 @@ class NextcloudTalkClient
             $body['replyTo'] = $options['replyTo'];
         }
 
-        if (!empty($options['silent'])) {
+        if (! empty($options['silent'])) {
             $body['silent'] = true;
         }
 
@@ -135,7 +135,7 @@ class NextcloudTalkClient
      * for bot messages and notification routing.
      *
      * @param  NextcloudConnection  $connection  The Nextcloud connection to use
-     * @return array  List of conversations with token, name, type, and displayName
+     * @return array List of conversations with token, name, type, and displayName
      */
     public function listConversations(NextcloudConnection $connection): array
     {
@@ -167,7 +167,7 @@ class NextcloudTalkClient
      *
      * @param  NextcloudConnection  $connection  The Nextcloud connection to use
      * @param  string  $conversationToken  The conversation token
-     * @return array  Conversation details
+     * @return array Conversation details
      */
     public function getConversation(NextcloudConnection $connection, string $conversationToken): array
     {
@@ -190,7 +190,7 @@ class NextcloudTalkClient
      * @param  string  $roomName  The name for the new conversation
      * @param  int  $roomType  1=group, 2=public, 3=one-to-one (deprecated), 4=changelog
      * @param  array  $options  Optional: password, object, invite users/groups
-     * @return array  Created conversation data
+     * @return array Created conversation data
      */
     public function createConversation(NextcloudConnection $connection, string $roomName, int $roomType = 1, array $options = []): array
     {
@@ -220,20 +220,24 @@ class NextcloudTalkClient
     }
 
     /**
-     * Verify an incoming webhook signature from a Talk bot.
+     * Verify an incoming webhook signature from Nextcloud Talk.
      *
-     * Use this to validate that incoming requests to Nexum's webhook endpoint
-     * are genuinely from the Nextcloud Talk server.
+     * IMPORTANT: Inbound webhooks from Nextcloud use headers WITHOUT the
+     * "Bot-" prefix (X-Nextcloud-Talk-Random, X-Nextcloud-Talk-Signature),
+     * while outbound bot messages TO Nextcloud use the "Bot-" prefix
+     * (X-Nextcloud-Talk-Bot-Random, X-Nextcloud-Talk-Bot-Signature).
+     *
+     * The signature covers random + raw body (the full JSON payload).
+     * This differs from outbound where the signature covers random + message text only.
      *
      * @param  string  $secret  The bot's shared secret
      * @param  string  $randomHeader  The X-Nextcloud-Talk-Random header value
      * @param  string  $signatureHeader  The X-Nextcloud-Talk-Signature header value
      * @param  string  $body  The raw request body
-     * @return bool  True if the signature is valid
      */
     public function verifyIncomingSignature(string $secret, string $randomHeader, string $signatureHeader, string $body): bool
     {
-        $expectedSignature = hash_hmac('sha256', $randomHeader . $body, $secret);
+        $expectedSignature = hash_hmac('sha256', $randomHeader.$body, $secret);
 
         return hash_equals(strtolower($expectedSignature), strtolower($signatureHeader));
     }
@@ -242,7 +246,7 @@ class NextcloudTalkClient
      * Check if the Talk server supports the bots-v1 capability.
      *
      * @param  NextcloudConnection  $connection  The Nextcloud connection to check
-     * @return bool  True if bots-v1 is supported
+     * @return bool True if bots-v1 is supported
      */
     public function supportsBots(NextcloudConnection $connection): bool
     {
@@ -270,7 +274,7 @@ class NextcloudTalkClient
      * This method extracts the key fields into a convenient array.
      *
      * @param  array  $payload  The parsed JSON payload from Talk
-     * @return array  Normalized message data
+     * @return array Normalized message data
      */
     public function parseIncomingMessage(array $payload): array
     {
@@ -314,7 +318,7 @@ class NextcloudTalkClient
      * List bots installed on the Nextcloud server (admin only).
      *
      * @param  NextcloudConnection  $connection  The Nextcloud connection (admin credentials)
-     * @return array  List of installed bots
+     * @return array List of installed bots
      */
     public function listInstalledBots(NextcloudConnection $connection): array
     {

--- a/tests/Unit/Modules/Nextcloud/Services/NextcloudTalkClientTest.php
+++ b/tests/Unit/Modules/Nextcloud/Services/NextcloudTalkClientTest.php
@@ -57,8 +57,8 @@ class NextcloudTalkClientTest extends TestCase
         $this->assertEquals(['id' => 42], $result);
 
         Http::assertSent(function ($request) {
-            return $request->hasHeader('X-Nextcloud-Talk-Random')
-                && $request->hasHeader('X-Nextcloud-Talk-Signature')
+            return $request->hasHeader('X-Nextcloud-Talk-Bot-Random')
+                && $request->hasHeader('X-Nextcloud-Talk-Bot-Signature')
                 && $request->hasHeader('OCS-APIRequest')
                 && $request->url() === 'https://nextcloud.example.com/ocs/v2.php/apps/spreed/api/v1/bot/abc123xyz/message'
                 && $request->method() === 'POST';
@@ -140,13 +140,51 @@ class NextcloudTalkClientTest extends TestCase
     }
 
     #[Test]
+    public function it_signs_bot_message_over_random_and_plain_text(): void
+    {
+        Http::fake([
+            'nextcloud.example.com/ocs/v2.php/apps/spreed/api/v1/bot/testtoken/message' => Http::response([
+                'ocs' => [
+                    'meta' => ['status' => 'ok', 'statuscode' => 201],
+                    'data' => ['id' => 1],
+                ],
+            ], 201),
+        ]);
+
+        $this->client->sendBotMessage(
+            $this->connection,
+            'testtoken',
+            'Hello from Nexum!',
+        );
+
+        // The Talk Bot API signs over random + plain message text, NOT the JSON body.
+        // Verify the signature matches random + message, not random + jsonString.
+        Http::assertSent(function ($request) {
+            $random = $request->header('X-Nextcloud-Talk-Bot-Random')[0] ?? '';
+            $signature = strtolower($request->header('X-Nextcloud-Talk-Bot-Signature')[0] ?? '');
+            $secret = $this->connection->getTalkBotSecret();
+            $message = 'Hello from Nexum!';
+
+            $expectedOverMessage = hash_hmac('sha256', $random.$message, $secret);
+            $expectedOverBody = hash_hmac('sha256', $random.$request->body(), $secret);
+
+            // Signature must match random + plain message text
+            $matchesMessageHash = hash_equals($expectedOverMessage, $signature);
+            // And must NOT match random + JSON body (which would be a regression)
+            $matchesBodyHash = hash_equals($expectedOverBody, $signature);
+
+            return $matchesMessageHash && ! $matchesBodyHash;
+        });
+    }
+
+    #[Test]
     public function it_verifies_incoming_signatures(): void
     {
         $secret = 'my-bot-secret';
         $random = bin2hex(random_bytes(32));
         $body = json_encode(['type' => 'Activity', 'object' => ['content' => 'hello']]);
 
-        $signature = hash_hmac('sha256', $random . $body, $secret);
+        $signature = hash_hmac('sha256', $random.$body, $secret);
 
         $this->assertTrue(
             $this->client->verifyIncomingSignature($secret, $random, $signature, $body)

--- a/tests/Unit/Modules/Notification/Channels/NextcloudTalkChannelTest.php
+++ b/tests/Unit/Modules/Notification/Channels/NextcloudTalkChannelTest.php
@@ -2,13 +2,13 @@
 
 namespace Tests\Unit\Modules\Notification\Channels;
 
+use App\Models\Core\User;
 use App\Modules\Nextcloud\Models\NextcloudConnection;
 use App\Modules\Notification\Channels\NextcloudTalkChannel;
 use App\Modules\Notification\Models\NotificationChannel;
 use App\Modules\Notification\Models\NotificationSetting;
 use App\Modules\Notification\Notifications\TicketAssigned;
 use App\Modules\Ticket\Models\Ticket;
-use App\Models\Core\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use PHPUnit\Framework\Attributes\Test;
@@ -79,8 +79,8 @@ class NextcloudTalkChannelTest extends TestCase
         // Should have made a bot API call (signed message)
         Http::assertSent(function ($request) {
             return str_contains($request->url(), '/bot/support-room/message')
-                && $request->hasHeader('X-Nextcloud-Talk-Random')
-                && $request->hasHeader('X-Nextcloud-Talk-Signature')
+                && $request->hasHeader('X-Nextcloud-Talk-Bot-Random')
+                && $request->hasHeader('X-Nextcloud-Talk-Bot-Signature')
                 && $request->hasHeader('OCS-APIRequest');
         });
     }
@@ -122,7 +122,7 @@ class NextcloudTalkChannelTest extends TestCase
         // Should have made a webhook POST (no signing headers)
         Http::assertSent(function ($request) use ($webhookUrl) {
             return $request->url() === $webhookUrl
-                && !$request->hasHeader('X-Nextcloud-Talk-Signature');
+                && ! $request->hasHeader('X-Nextcloud-Talk-Bot-Signature');
         });
     }
 


### PR DESCRIPTION
Two bugs in the Talk Bot integration:

1. Wrong header names: The Talk Bot API (bot → Nextcloud) uses X-Nextcloud-Talk-Bot-Random and X-Nextcloud-Talk-Bot-Signature (with 'Bot-' prefix), while inbound webhooks (Nextcloud → bot) use X-Nextcloud-Talk-Random/X-Nextcloud-Talk-Signature (no prefix). The outbound sendBotMessage() was missing the 'Bot-' prefix, causing Nextcloud to return 400 (headers not recognized).

2. Wrong signature payload: The Talk Bot API signs over random + plain message text (not random + JSON body). sendBotMessage() was signing random + jsonBody, which Nextcloud would reject as invalid HMAC.

Also updated TalkWebhookController docs and verifyIncomingSignature() comments to clearly document the asymmetry between inbound/outbound header names and signature payloads.

All tests updated (TalkClientTest, TalkWebhookTest, TalkChannelTest).