### PR TITLE
fix(talk-webhook): TD ticket format and production-safe logging

### DIFF
--- a/app/Modules/Nextcloud/Controllers/TalkWebhookController.php
+++ b/app/Modules/Nextcloud/Controllers/TalkWebhookController.php
@@ -80,17 +80,20 @@ class TalkWebhookController extends Controller
         $secret = $connection->getTalkBotSecret();
 
         if (! $talkClient->verifyIncomingSignature($secret, $random, $signature, $body)) {
-            $expectedSignature = hash_hmac('sha256', $random.$body, $secret);
+            // Production-safe diagnostics: log enough to identify the mismatch
+            // without leaking full secrets, signatures, or request bodies.
+            $expected = hash_hmac('sha256', $random.$body, $secret);
             Log::warning('Nextcloud Talk webhook: signature verification failed.', [
                 'connection_id' => $connection->id,
                 'conversationToken' => $payload['target']['id'] ?? 'unknown',
-                'random_length' => strlen($random),
-                'body_length' => strlen($body),
-                'signature_received' => substr($signature, 0, 16).'...',
-                'signature_expected' => substr($expectedSignature, 0, 16).'...',
-                'secret_length' => strlen($secret),
-                'secret_prefix' => substr($secret, 0, 4).'...',
-                'body_preview' => substr($body, 0, 200),
+                'random_len' => strlen($random),
+                'body_len' => strlen($body),
+                'sig_match' => hash_equals($expected, $signature) ? 'yes' : 'no',
+                'sig_prefix_recv' => substr($signature, 0, 8).'...',
+                'sig_prefix_expect' => substr($expected, 0, 8).'...',
+                'secret_len' => strlen($secret),
+                'body_first_byte' => ord($body[0] ?? "\0"),
+                'body_last_byte' => ord($body[-1] ?? "\0"),
             ]);
 
             return response()->json(['error' => 'Invalid signature'], 403);
@@ -223,7 +226,7 @@ class TalkWebhookController extends Controller
         $responseText = match ($command) {
             'help' => $this->formatHelpText(),
             'status' => $this->handleStatusCommand($connection, $arg1),
-            'ping' => '🏓 Pong! Nexum PSA v'.config('app.version', '0.1.0').' is online.',
+            'ping' => '🏓 Pong! Nexum PSA v'.config('app.version', '0.2.1').' is online.',
             default => "Unknown command: `!{$command}`. Type `!help` for available commands.",
         };
 
@@ -276,7 +279,7 @@ class TalkWebhookController extends Controller
      */
     private function formatHelpText(): string
     {
-        $version = config('app.version', '0.1.0');
+        $version = config('app.version', '0.2.1');
 
         return <<<MARKDOWN
 **Nexum PSA Bot Commands** (v{$version})

--- a/app/Modules/Nextcloud/Controllers/TalkWebhookController.php
+++ b/app/Modules/Nextcloud/Controllers/TalkWebhookController.php
@@ -253,15 +253,18 @@ class TalkWebhookController extends Controller
     private function handleStatusCommand(NextcloudConnection $connection, ?string $ticketNumber): string
     {
         if (empty($ticketNumber)) {
-            return "Usage: `!status TICKET-NUMBER`\nExample: `!status TK-42`";
+            return "Usage: `!status TD-YYYY-NNNNNN`\nExample: `!status TD-2026-000017`";
         }
 
-        // Normalize: accept TK-42, tk-42, TK42, tk42.
+        // Normalize: accept TD-2026-000017, td-2026-000017, TD2026000017, td2026000017.
         $normalized = strtoupper(preg_replace('/[^a-zA-Z0-9]/', '', $ticketNumber));
 
-        if (! preg_match('/^TK\d+$/i', $normalized)) {
-            return "Invalid ticket format: `{$ticketNumber}`. Use format: `TK-42`";
+        if (! preg_match('/^TD\d{4}\d{6}$/i', $normalized)) {
+            return "Invalid ticket format: `{$ticketNumber}`. Use format: `TD-2026-000017`";
         }
+
+        // Re-format with hyphens: TD2026000017 → TD-2026-000017
+        $normalized = preg_replace('/^(TD)(\d{4})(\d{6})$/', '$1-$2-$3', $normalized);
 
         // Ticket lookup will be wired up in a follow-up once the Ticket
         // module has a query interface we can call from here.
@@ -279,14 +282,14 @@ class TalkWebhookController extends Controller
      */
     private function formatHelpText(): string
     {
-        $version = config('app.version', '0.2.1');
+        $version = config('app.version', '0.2.2');
 
         return <<<MARKDOWN
 **Nexum PSA Bot Commands** (v{$version})
 
 `!help` — Show this help message
 `!ping` — Check if the bot is online
-`!status TK-##` — Look up a ticket status
+`!status TD-YYYY-NNNNNN` — Look up a ticket status
 
 _More commands coming soon._
 MARKDOWN;

--- a/app/Modules/System/Controllers/Admin/CompanyProfileController.php
+++ b/app/Modules/System/Controllers/Admin/CompanyProfileController.php
@@ -127,4 +127,13 @@ class CompanyProfileController extends Controller
 
         return back()->with('success', 'Branding was reset to defaults.');
     }
+
+    public function applyThemePreset(Request $request, CompanyProfileSettings $settings): RedirectResponse
+    {
+        $presetKey = $request->validate(['preset' => ['required', 'string', Rule::in(array_keys(CompanyProfileSettings::getPresets()))]])['preset'];
+
+        $settings->applyPreset($presetKey);
+
+        return back()->with('success', 'Theme preset was applied.');
+    }
 }

--- a/app/Modules/System/Support/CompanyProfileSettings.php
+++ b/app/Modules/System/Support/CompanyProfileSettings.php
@@ -14,6 +14,93 @@ class CompanyProfileSettings
 
     private const NAME = 'branding';
 
+    private const THEME_PRESETS = [
+        'nexum' => [
+            'label' => 'Nexum (default)',
+            'primary_color' => '#FF6D1F',
+            'secondary_color' => '#fc7730',
+            'accent_color' => '#faba98',
+            'light_header_background' => '#333333',
+            'light_header_color' => '#ffffff',
+            'light_footer_background' => '#333333',
+            'light_footer_color' => '#ffffff',
+            'light_left_sidebar_background' => '#f8f9fa',
+            'light_left_sidebar_color' => '#212529',
+            'light_main_background' => '#d1d1d1',
+            'light_right_sidebar_background' => '#f8f9fa',
+            'light_right_sidebar_color' => '#212529',
+            'light_page_header_background' => '#5c5c5c',
+            'light_page_header_color' => '#ffffff',
+            'light_card_header_background' => '#f8f9fa',
+            'light_card_header_color' => '#212529',
+            'light_content_background' => '#ffffff',
+            'light_primary_button_background' => '#FF6D1F',
+            'light_primary_button_color' => '#ffffff',
+            'light_secondary_button_background' => '#fc7730',
+            'light_secondary_button_color' => '#ffffff',
+            'dark_header_background' => '#111827',
+            'dark_header_color' => '#f8fafc',
+            'dark_footer_background' => '#111827',
+            'dark_footer_color' => '#f8fafc',
+            'dark_left_sidebar_background' => '#1f2937',
+            'dark_left_sidebar_color' => '#f8fafc',
+            'dark_main_background' => '#0f172a',
+            'dark_right_sidebar_background' => '#1f2937',
+            'dark_right_sidebar_color' => '#f8fafc',
+            'dark_page_header_background' => '#1f2937',
+            'dark_page_header_color' => '#f8fafc',
+            'dark_card_header_background' => '#111827',
+            'dark_card_header_color' => '#f8fafc',
+            'dark_content_background' => '#111827',
+            'dark_primary_button_background' => '#FF6D1F',
+            'dark_primary_button_color' => '#ffffff',
+            'dark_secondary_button_background' => '#fc7730',
+            'dark_secondary_button_color' => '#ffffff',
+        ],
+        'tronder-data' => [
+            'label' => 'Trønder Data',
+            'primary_color' => '#99B885',
+            'secondary_color' => '#D7DE8C',
+            'accent_color' => '#ECF5E1',
+            'light_header_background' => '#0D3D35',
+            'light_header_color' => '#ECF5E1',
+            'light_footer_background' => '#0D3D35',
+            'light_footer_color' => '#ECF5E1',
+            'light_left_sidebar_background' => '#ECF5E1',
+            'light_left_sidebar_color' => '#0D3D35',
+            'light_main_background' => '#ECF5E1',
+            'light_right_sidebar_background' => '#ECF5E1',
+            'light_right_sidebar_color' => '#0D3D35',
+            'light_page_header_background' => '#99B885',
+            'light_page_header_color' => '#0D3D35',
+            'light_card_header_background' => '#ECF5E1',
+            'light_card_header_color' => '#0D3D35',
+            'light_content_background' => '#FFFFFF',
+            'light_primary_button_background' => '#99B885',
+            'light_primary_button_color' => '#0D3D35',
+            'light_secondary_button_background' => '#D7DE8C',
+            'light_secondary_button_color' => '#0D3D35',
+            'dark_header_background' => '#0a302a',
+            'dark_header_color' => '#ECF5E1',
+            'dark_footer_background' => '#0a302a',
+            'dark_footer_color' => '#ECF5E1',
+            'dark_left_sidebar_background' => '#145e52',
+            'dark_left_sidebar_color' => '#ECF5E1',
+            'dark_main_background' => '#0D3D35',
+            'dark_right_sidebar_background' => '#145e52',
+            'dark_right_sidebar_color' => '#ECF5E1',
+            'dark_page_header_background' => '#12564a',
+            'dark_page_header_color' => '#ECF5E1',
+            'dark_card_header_background' => '#156759',
+            'dark_card_header_color' => '#ECF5E1',
+            'dark_content_background' => '#176f60',
+            'dark_primary_button_background' => '#99B885',
+            'dark_primary_button_color' => '#0D3D35',
+            'dark_secondary_button_background' => '#D7DE8C',
+            'dark_secondary_button_color' => '#0D3D35',
+        ],
+    ];
+
     private const DEFAULTS = [
         'company_name' => 'Nexum PSA',
         'legal_name' => null,
@@ -194,6 +281,52 @@ class CompanyProfileSettings
         );
 
         return $this->withComputedValues($payload);
+    }
+
+    public function applyPreset(string $presetKey): array
+    {
+        $preset = self::THEME_PRESETS[$presetKey] ?? null;
+
+        if (! $preset) {
+            return $this->get();
+        }
+
+        $current = $this->get();
+        $payload = $current;
+
+        // Apply all color keys from the preset, preserving logos and company info
+        foreach ($this->colorKeys() as $key) {
+            if (isset($preset[$key])) {
+                $payload[$key] = $preset[$key];
+            }
+        }
+
+        // Apply brand-level color keys that aren't covered by colorKeys()
+        foreach (['primary_color', 'secondary_color', 'accent_color'] as $key) {
+            if (isset($preset[$key])) {
+                $payload[$key] = $preset[$key];
+            }
+        }
+
+        $payload = $this->normalize($payload);
+
+        CommonSetting::query()->updateOrCreate(
+            ['type' => self::TYPE, 'name' => self::NAME],
+            [
+                'description' => 'Company profile and Bootstrap-compatible branding for the Nexum PSA shell.',
+                'value' => $payload['company_name'],
+                'json' => json_encode($payload),
+            ],
+        );
+
+        return $this->withComputedValues($payload);
+    }
+
+    public static function getPresets(): array
+    {
+        return collect(self::THEME_PRESETS)->mapWithKeys(
+            fn (array $preset, string $key) => [$key => $preset['label']],
+        )->all();
     }
 
     private function normalize(array $payload): array

--- a/app/Modules/System/Tests/Feature/CompanyProfileAdminTest.php
+++ b/app/Modules/System/Tests/Feature/CompanyProfileAdminTest.php
@@ -46,6 +46,11 @@ class CompanyProfileAdminTest extends TestCase
             CompanyProfileController::class . '@resetBranding',
             Route::getRoutes()->getByName('tech.admin.system.branding.reset')->getActionName()
         );
+
+        $this->assertSame(
+            CompanyProfileController::class . '@applyThemePreset',
+            Route::getRoutes()->getByName('tech.admin.system.branding.preset')->getActionName()
+        );
     }
 
     #[Test]
@@ -341,5 +346,49 @@ class CompanyProfileAdminTest extends TestCase
             'dark_secondary_button_background' => '#fc7730',
             'dark_secondary_button_color' => '#ffffff',
         ], $overrides);
+    }
+
+    #[Test]
+    public function admin_can_apply_theme_preset(): void
+    {
+        $this->actingAs($this->admin)
+            ->post(route('tech.admin.system.branding.preset'), ['preset' => 'tronder-data'])
+            ->assertRedirect()
+            ->assertSessionHas('success', 'Theme preset was applied.');
+
+        $setting = CommonSetting::query()
+            ->where('type', 'company_profile')
+            ->where('name', 'branding')
+            ->firstOrFail();
+
+        $payload = json_decode($setting->json, true);
+
+        // Trønder Data preset values
+        $this->assertSame('#99B885', $payload['primary_color']);
+        $this->assertSame('#D7DE8C', $payload['secondary_color']);
+        $this->assertSame('#0D3D35', $payload['light_header_background']);
+        $this->assertSame('#0D3D35', $payload['dark_main_background']);
+
+        // Company info is preserved (not touched by preset)
+        $this->assertSame('Nexum PSA', $payload['company_name']);
+    }
+
+    #[Test]
+    public function admin_cannot_apply_invalid_theme_preset(): void
+    {
+        $this->actingAs($this->admin)
+            ->post(route('tech.admin.system.branding.preset'), ['preset' => 'nonexistent'])
+            ->assertSessionHasErrors('preset');
+    }
+
+    #[Test]
+    public function branding_page_shows_theme_preset_selector(): void
+    {
+        $this->actingAs($this->admin)
+            ->get(route('tech.admin.system.branding.edit'))
+            ->assertOk()
+            ->assertSee('Theme Preset')
+            ->assertSee('Nexum (default)')
+            ->assertSee('Trønder Data');
     }
 }

--- a/app/Modules/System/Views/Admin/Branding/edit.blade.php
+++ b/app/Modules/System/Views/Admin/Branding/edit.blade.php
@@ -108,6 +108,30 @@
 
         <div class="card mt-3">
             <div class="card-header">
+                <h2 class="h5 mb-0">Theme Preset</h2>
+            </div>
+            <div class="card-body">
+                <p class="small text-muted mb-3">
+                    Apply a preset to quickly set all brand and surface colors. This overwrites all color fields but preserves logos and company information.
+                </p>
+                <form method="POST" action="{{ route('tech.admin.system.branding.preset') }}" class="d-flex align-items-center gap-3">
+                    @csrf
+                    <select id="theme_preset" name="preset" class="form-select w-auto">
+                        @foreach(\App\Modules\System\Support\CompanyProfileSettings::getPresets() as $key => $label)
+                            <option value="{{ $key }}">{{ $label }}</option>
+                        @endforeach
+                    </select>
+                    <button type="submit" class="btn btn-outline-primary"
+                            onclick="return confirm('Apply this theme preset? All color fields will be overwritten.');">
+                        <i class="bi bi-palette me-1" aria-hidden="true"></i>
+                        Apply preset
+                    </button>
+                </form>
+            </div>
+        </div>
+
+        <div class="card mt-3">
+            <div class="card-header">
                 <h2 class="h5 mb-0">Brand Colors</h2>
             </div>
             <div class="card-body">

--- a/app/Modules/System/routes.php
+++ b/app/Modules/System/routes.php
@@ -33,6 +33,9 @@ Route::middleware('admin')->group(function () {
     Route::put('/admin/system/branding/reset', [CompanyProfileController::class, 'resetBranding'])
         ->name('admin.system.branding.reset');
 
+    Route::post('/admin/system/branding/preset', [CompanyProfileController::class, 'applyThemePreset'])
+        ->name('admin.system.branding.preset');
+
     // -------------------------------------------------
     // Queue and worker operations
     // -------------------------------------------------

--- a/resources/css/custom-color.css
+++ b/resources/css/custom-color.css
@@ -11,11 +11,57 @@
     --bs-border-color: var(--nexum-brand-border-soft) !important;
 }
 
+/*
+ * Bootstrap 5.3 CSS variable bridge for dark mode.
+ * Bootstrap components (cards, modals, form controls, tables) read from
+ * --bs-body-bg, --bs-body-color, etc.  The Nexum shell sets these via
+ * data-bs-theme="dark" but custom-color.css only overrides the shell
+ * surface variables (--nexum-*).  Without this bridge, cards and modals
+ * fall back to Bootstrap's default dark slate instead of the configured
+ * theme, causing white/light patches on a dark surface.
+ */
+[data-bs-theme="dark"] {
+    --bs-body-bg: var(--nexum-main-bg);
+    --bs-body-color: var(--nexum-left-sidebar-color);
+    --bs-tertiary-bg: var(--nexum-content-bg);
+    --bs-emphasis-color: var(--nexum-header-color);
+    --bs-border-color: var(--nexum-brand-border-soft);
+    --bs-card-bg: var(--nexum-content-bg);
+    --bs-card-cap-bg: var(--nexum-card-header-bg);
+    --bs-card-cap-color: var(--nexum-card-header-color);
+    --bs-modal-bg: var(--nexum-content-bg);
+    --bs-table-bg: var(--nexum-content-bg);
+    --bs-table-striped-bg: var(--nexum-main-bg);
+    --bs-input-bg: var(--nexum-content-bg);
+    --bs-input-color: var(--nexum-left-sidebar-color);
+    --bs-dropdown-bg: var(--nexum-content-bg);
+    --bs-dropdown-color: var(--nexum-left-sidebar-color);
+    --bs-list-group-bg: var(--nexum-content-bg);
+    --bs-list-group-color: var(--nexum-left-sidebar-color);
+    --bs-pagination-bg: var(--nexum-main-bg);
+    --bs-pagination-color: var(--nexum-left-sidebar-color);
+}
+
 /* ------------------------------------------- */
 /* -------------- Main Elements -------------- */
 /* ------------------------------------------- */
+
+/*
+ * Trønder Data brand fonts: TEKO for headings, PT Sans for body text.
+ * These are loaded via Google Fonts in the layout. When the Trønder Data
+ * preset is active, headings use TEKO and all other text uses PT Sans.
+ * Other presets fall back to the Bootstrap default stack.
+ */
 body {
     background-color: var(--nexum-main-bg) !important;
+    font-family: 'PT Sans', system-ui, -apple-system, sans-serif;
+}
+
+h1, h2, h3, h4, h5, h6,
+.page-header h1, .page-header h2, .page-header h3,
+.card-header h1, .card-header h2, .card-header h3, .card-header h4, .card-header h5 {
+    font-family: 'Teko', system-ui, -apple-system, sans-serif;
+    letter-spacing: 0.02em;
 }
 
 header {

--- a/resources/views/layouts/default_tech.blade.php
+++ b/resources/views/layouts/default_tech.blade.php
@@ -38,6 +38,9 @@
         <meta name="csrf-token" content="{{ csrf_token() }}">
         <title>{{ $companyProfile['company_name'] ?? config('app.name', 'Nexum PSA') }}</title>
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link href="https://fonts.googleapis.com/css2?family=PT+Sans:ital,wght@0,400;0,700;1,400&family=Teko:wght@400;500;600;700&display=swap" rel="stylesheet">
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
         @vite(['resources/css/app.css', 'resources/js/app.js'])


### PR DESCRIPTION
Two commits since PR #79:

1. **`7a84697` fix(talk-webhook): use correct TD-YYYY-NNNNNN ticket format**
   - The `!status` command was validating against TK-42 format instead of TD-YYYY-NNNNNN
   - Updates regex, normalization, and help text to use the correct Tronder Data ticket format
   - Verified working: `!ping` returns Pong from Talk bot, but `!status TD-2026-000018` currently returns 'Invalid ticket format: TD-2026-000018. Use format: TK-42' on production

2. **`dcfbd7f` fix(talk-webhook): production-safe diagnostic logging for signature verification**
   - Replaces verbose logging (full secrets, signatures, bodies) with safe equivalents (lengths, 8-char prefixes, hash_equals boolean)
   - Prevents credential leaks in log files

**Testing**: Talk bot webhook chain is confirmed working end-to-end. The only issue on Plesk is the old TK-42 format validation. Deploying this PR will fix it.