### PR TITLE
fix(contact): clean up legacy orphan client users

### DIFF
--- a/app/Modules/Contact/Actions/RepairContactOwnership.php
+++ b/app/Modules/Contact/Actions/RepairContactOwnership.php
@@ -335,6 +335,106 @@ class RepairContactOwnership
         ];
     }
 
+    public function cleanupLegacyOrphans(
+        Client $client,
+        array $clientUserIds,
+        bool $dryRun,
+        ?string $reason,
+        Request $request
+    ): array {
+        $client->loadMissing('sites');
+        $siteIds = $client->sites->pluck('id')->map(fn ($id) => (int) $id)->all();
+        $uniqueIds = collect($clientUserIds)->map(fn ($id) => (int) $id)->unique()->values()->all();
+        $rows = ClientUser::query()
+            ->with('site.client')
+            ->whereIn('id', $uniqueIds)
+            ->get()
+            ->keyBy('id');
+
+        $results = [];
+        $deleteIds = [];
+
+        foreach ($uniqueIds as $clientUserId) {
+            /** @var ClientUser|null $clientUser */
+            $clientUser = $rows->get($clientUserId);
+
+            if (! $clientUser) {
+                $results[] = [
+                    'client_user_id' => $clientUserId,
+                    'status' => 'missing_client_user',
+                    'message' => 'Client user was not found.',
+                ];
+
+                continue;
+            }
+
+            if (! in_array((int) $clientUser->client_site_id, $siteIds, true)) {
+                $results[] = [
+                    'client_user_id' => $clientUserId,
+                    'status' => 'wrong_client',
+                    'message' => 'Client user does not belong to the selected Client.',
+                    'client_user' => $this->legacyClientUserPayload($clientUser),
+                ];
+
+                continue;
+            }
+
+            if ($clientUser->contact_id) {
+                $results[] = [
+                    'client_user_id' => $clientUserId,
+                    'status' => 'linked_contact',
+                    'message' => 'Client user is linked to a Contact. Use the Contact detach endpoint instead.',
+                    'client_user' => $this->legacyClientUserPayload($clientUser),
+                ];
+
+                continue;
+            }
+
+            $deleteIds[] = $clientUserId;
+            $results[] = [
+                'client_user_id' => $clientUserId,
+                'status' => $dryRun ? 'would_delete' : 'deleted',
+                'client_user' => $this->legacyClientUserPayload($clientUser),
+            ];
+        }
+
+        if (! $dryRun && $deleteIds !== []) {
+            ClientUser::query()
+                ->whereIn('id', $deleteIds)
+                ->whereIn('client_site_id', $siteIds)
+                ->whereNull('contact_id')
+                ->delete();
+        }
+
+        $summary = [
+            'total' => count($uniqueIds),
+            'eligible' => count($deleteIds),
+            'changed' => $dryRun ? 0 : count($deleteIds),
+            'dry_run' => $dryRun,
+            'skipped' => collect($results)
+                ->whereIn('status', ['missing_client_user', 'wrong_client', 'linked_contact'])
+                ->count(),
+            'missing_client_users' => collect($results)->where('status', 'missing_client_user')->count(),
+            'wrong_client' => collect($results)->where('status', 'wrong_client')->count(),
+            'linked_contacts' => collect($results)->where('status', 'linked_contact')->count(),
+        ];
+
+        $auditId = $this->recordAudit($request, 'contact_ownership.legacy_orphan_cleanup', null, $client, null, $dryRun, $reason, [
+            'client_user_ids' => $uniqueIds,
+            'delete_client_user_ids' => $deleteIds,
+        ], [
+            'summary' => $summary,
+            'results' => $results,
+        ]);
+
+        return [
+            'client' => $this->clientPayload($client),
+            'summary' => $summary,
+            'audit_id' => $auditId,
+            'results' => $results,
+        ];
+    }
+
     private function buildMovePlan(Contact $contact, Client $targetClient, ?ClientSite $targetSite, bool $bulkMode): array
     {
         $contact->loadMissing(['emails', 'phones', 'relations']);

--- a/app/Modules/Contact/Controllers/Api/V1/ContactOwnershipController.php
+++ b/app/Modules/Contact/Controllers/Api/V1/ContactOwnershipController.php
@@ -101,4 +101,22 @@ class ContactOwnershipController extends Controller
             $request,
         ));
     }
+
+    public function cleanupLegacyOrphans(string $client, Request $request, RepairContactOwnership $repair): JsonResponse
+    {
+        $validated = $request->validate([
+            'client_user_ids' => ['required', 'array', 'min:1', 'max:500'],
+            'client_user_ids.*' => ['integer'],
+            'dry_run' => ['sometimes', 'boolean'],
+            'reason' => ['nullable', 'string', 'max:500'],
+        ]);
+
+        return response()->json($repair->cleanupLegacyOrphans(
+            $repair->resolveClient($client),
+            $validated['client_user_ids'],
+            (bool) ($validated['dry_run'] ?? true),
+            $validated['reason'] ?? null,
+            $request,
+        ));
+    }
 }

--- a/app/Modules/Contact/Docs/knowledge/contact-domain-overview.md
+++ b/app/Modules/Contact/Docs/knowledge/contact-domain-overview.md
@@ -140,6 +140,7 @@ Routes:
 - `GET /api/v1/clients/{client}/contacts`
 - `POST /api/v1/contacts/{contact}/move`
 - `POST /api/v1/clients/{client}/contacts/bulk-fix`
+- `POST /api/v1/clients/{client}/contacts/legacy-orphans/cleanup`
 - `DELETE /api/v1/clients/{client}/contacts/{contact}`
 
 The `{client}` value can be either the internal Client ID or the Client's `client_number`. If one
@@ -165,6 +166,11 @@ Client/Site relation, and moves or creates one `client_users` bridge row for the
 statuses such as `no_change`, `would_move`, `would_attach`, `conflict`, and `missing_contact`.
 Bulk-fix is conservative: Contacts with multiple current Client owners or multiple linked legacy
 rows are reported as conflicts for manual review.
+
+`POST /api/v1/clients/{client}/contacts/legacy-orphans/cleanup` accepts `client_user_ids`,
+`dry_run`, and `reason`. It is only for legacy `client_users` rows that belong to the selected
+Client and have no `contact_id`; linked rows are skipped and should be handled through Contact
+detach.
 
 `DELETE /api/v1/clients/{client}/contacts/{contact}` detaches the Contact from that Client. It
 removes Contact relations for the Client and its Sites and deletes linked legacy `client_users` rows

--- a/app/Modules/Contact/README.md
+++ b/app/Modules/Contact/README.md
@@ -51,6 +51,7 @@ Supported routes:
 - `GET /api/v1/clients/{client}/contacts`
 - `POST /api/v1/contacts/{contact}/move`
 - `POST /api/v1/clients/{client}/contacts/bulk-fix`
+- `POST /api/v1/clients/{client}/contacts/legacy-orphans/cleanup`
 - `DELETE /api/v1/clients/{client}/contacts/{contact}`
 
 `{client}` accepts the internal Client ID or `client_number`. This is important in production where
@@ -60,6 +61,9 @@ Mutating ownership routes require the `contacts.ownership_manage` API scope and 
 Actual moves update `contact_relations` and the linked `client_users` bridge in one transaction.
 Detach removes the selected Client and Site relations and deletes linked legacy `client_users` rows
 for that Client, but it does not hard-delete the Contact by default.
+Legacy orphan cleanup deletes explicitly selected `client_users` rows only when they belong to the
+selected Client and have no linked Contact. Rows with a `contact_id` must use the Contact detach
+endpoint instead.
 
 Repair calls are written to the activity log with the actor, API token ID when available, reason,
 before state, result, and after state.

--- a/app/Modules/Contact/Tests/Feature/ContactModuleTest.php
+++ b/app/Modules/Contact/Tests/Feature/ContactModuleTest.php
@@ -576,6 +576,89 @@ class ContactModuleTest extends TestCase
     }
 
     #[Test]
+    public function api_user_can_cleanup_legacy_client_users_without_contacts(): void
+    {
+        $client = Client::factory()->create(['name' => 'Legacy Cleanup Client', 'client_number' => '30002']);
+        $site = ClientSite::factory()->create(['client_id' => $client->id, 'name' => 'Legacy Cleanup Site', 'is_default' => true]);
+        $otherClient = Client::factory()->create(['name' => 'Other Legacy Client', 'client_number' => '30003']);
+        $otherSite = ClientSite::factory()->create(['client_id' => $otherClient->id, 'name' => 'Other Legacy Site', 'is_default' => true]);
+
+        $orphanOne = ClientUser::factory()->create([
+            'client_site_id' => $site->id,
+            'contact_id' => null,
+            'name' => 'Imported Wrong One',
+            'email' => 'wrong-one@example.test',
+        ]);
+        $orphanTwo = ClientUser::factory()->create([
+            'client_site_id' => $site->id,
+            'contact_id' => null,
+            'name' => 'Imported Wrong Two',
+            'email' => 'wrong-two@example.test',
+        ]);
+        $linkedContact = Contact::query()->create([
+            'type' => 'person',
+            'status' => 'active',
+            'display_name' => 'Linked Contact',
+        ]);
+        $linkedRow = ClientUser::factory()->create([
+            'client_site_id' => $site->id,
+            'contact_id' => $linkedContact->id,
+            'name' => 'Linked Contact',
+            'email' => 'linked@example.test',
+        ]);
+        $otherRow = ClientUser::factory()->create([
+            'client_site_id' => $otherSite->id,
+            'contact_id' => null,
+            'name' => 'Other Client User',
+            'email' => 'other@example.test',
+        ]);
+
+        Sanctum::actingAs($this->techUser, ['contacts.ownership_manage']);
+
+        $payload = [
+            'client_user_ids' => [$orphanOne->id, $orphanTwo->id, $linkedRow->id, $otherRow->id, 999999],
+            'dry_run' => true,
+            'reason' => 'Preview legacy cleanup.',
+        ];
+
+        $this->postJson(route('api.v1.clients.contacts.legacy-orphans.cleanup', ['client' => $client->client_number]), $payload)
+            ->assertOk()
+            ->assertJsonPath('summary.total', 5)
+            ->assertJsonPath('summary.eligible', 2)
+            ->assertJsonPath('summary.changed', 0)
+            ->assertJsonPath('summary.skipped', 3)
+            ->assertJsonPath('results.0.status', 'would_delete')
+            ->assertJsonPath('results.1.status', 'would_delete')
+            ->assertJsonPath('results.2.status', 'linked_contact')
+            ->assertJsonPath('results.3.status', 'wrong_client')
+            ->assertJsonPath('results.4.status', 'missing_client_user');
+
+        $this->assertDatabaseHas('client_users', ['id' => $orphanOne->id]);
+        $this->assertDatabaseHas('client_users', ['id' => $orphanTwo->id]);
+
+        $payload['dry_run'] = false;
+        $payload['reason'] = 'Delete N8N-imported legacy rows.';
+
+        $this->postJson(route('api.v1.clients.contacts.legacy-orphans.cleanup', ['client' => $client->client_number]), $payload)
+            ->assertOk()
+            ->assertJsonPath('summary.total', 5)
+            ->assertJsonPath('summary.eligible', 2)
+            ->assertJsonPath('summary.changed', 2)
+            ->assertJsonPath('summary.skipped', 3)
+            ->assertJsonPath('results.0.status', 'deleted')
+            ->assertJsonPath('results.1.status', 'deleted');
+
+        $this->assertDatabaseMissing('client_users', ['id' => $orphanOne->id]);
+        $this->assertDatabaseMissing('client_users', ['id' => $orphanTwo->id]);
+        $this->assertDatabaseHas('client_users', ['id' => $linkedRow->id]);
+        $this->assertDatabaseHas('client_users', ['id' => $otherRow->id]);
+        $this->assertDatabaseHas('activity_log', [
+            'log_name' => 'contact_ownership',
+            'event' => 'contact_ownership.legacy_orphan_cleanup',
+        ]);
+    }
+
+    #[Test]
     public function contact_update_scope_cannot_move_contact_ownership(): void
     {
         $targetClient = Client::factory()->create(['client_number' => '40001']);

--- a/app/Modules/Contact/api.php
+++ b/app/Modules/Contact/api.php
@@ -33,6 +33,10 @@ Route::post('clients/{client}/contacts/bulk-fix', [ContactOwnershipController::c
     ->name('clients.contacts.bulk-fix')
     ->middleware(CheckAbilities::class.':contacts.ownership_manage');
 
+Route::post('clients/{client}/contacts/legacy-orphans/cleanup', [ContactOwnershipController::class, 'cleanupLegacyOrphans'])
+    ->name('clients.contacts.legacy-orphans.cleanup')
+    ->middleware(CheckAbilities::class.':contacts.ownership_manage');
+
 Route::delete('clients/{client}/contacts/{contact}', [ContactOwnershipController::class, 'detach'])
     ->name('clients.contacts.detach')
     ->middleware(CheckAbilities::class.':contacts.ownership_manage');

--- a/app/Modules/Integration/Docs/knowledge/api-management.md
+++ b/app/Modules/Integration/Docs/knowledge/api-management.md
@@ -98,6 +98,7 @@ Current API routes are under `/api/v1`:
 - `GET /api/v1/clients/{client}/contacts`
 - `POST /api/v1/contacts/{contact}/move`
 - `POST /api/v1/clients/{client}/contacts/bulk-fix`
+- `POST /api/v1/clients/{client}/contacts/legacy-orphans/cleanup`
 - `DELETE /api/v1/clients/{client}/contacts/{contact}`
 - `GET /api/v1/tickets`
 - `GET /api/v1/tickets/{ticket}`
@@ -273,6 +274,10 @@ Contact relations and the legacy Client User bridge.
 
 `POST /api/v1/clients/{client}/contacts/bulk-fix` accepts `contact_ids`, optional `target_site_id`,
 `dry_run`, and `reason`. Use `dry_run: true` first to get per-Contact statuses before mutating data.
+
+`POST /api/v1/clients/{client}/contacts/legacy-orphans/cleanup` accepts explicit `client_user_ids`,
+`dry_run`, and `reason`. It deletes only legacy rows for the selected Client that have no
+`contact_id`; linked rows are skipped and should be handled through Contact detach.
 
 `DELETE /api/v1/clients/{client}/contacts/{contact}` detaches a Contact from one Client. It deletes
 linked legacy `client_users` rows for that Client so the legacy contact does not remain visible on


### PR DESCRIPTION
Adds a narrow Contact ownership repair endpoint for legacy `client_users` rows that have no linked `contact_id`.

What changed:
- Adds `POST /api/v1/clients/{client}/contacts/legacy-orphans/cleanup`
- Requires `contacts.ownership_manage`
- Supports `dry_run`, `reason`, and explicit `client_user_ids`
- Deletes only rows that belong to the selected client and have no linked Contact
- Skips linked Contact rows, rows on other clients, and missing IDs
- Adds API coverage and docs

Verification:
- `php -d extension=C:\php\ext\php_zip.dll -d extension=C:\php\ext\php_pdo_sqlite.dll -d extension=C:\php\ext\php_sqlite3.dll vendor\bin\phpunit app/Modules/Contact/Tests/Feature/ContactModuleTest.php --filter='(contact_ownership|bulk_fix|detach_contact|cleanup_legacy|contact_update_scope)'` passed: 6 tests, 61 assertions.
- Full `ContactModuleTest` still needs the frontend Vite manifest in this local clone; unrelated UI tests fail without `public/build/manifest.json`.