### PR TITLE
Fix MySQL marketing migration index replacement

### DIFF
--- a/app/Modules/Marketing/Tests/Unit/MarketingLifecycleMigrationSafetyTest.php
+++ b/app/Modules/Marketing/Tests/Unit/MarketingLifecycleMigrationSafetyTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Modules\Marketing\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+class MarketingLifecycleMigrationSafetyTest extends TestCase
+{
+    public function test_email_foreign_key_index_is_created_before_the_old_unique_index_is_removed(): void
+    {
+        $migration = file_get_contents(
+            dirname(__DIR__, 5).'/database/migrations/2026_07_04_120000_complete_marketing_lifecycle_and_content_sources.php'
+        );
+
+        $supportingIndex = strpos(
+            $migration,
+            "'marketing_campaign_recipients_email_index'"
+        );
+        $oldUniqueDrop = strpos(
+            $migration,
+            "dropUnique('marketing_campaign_recipient_member_unique')"
+        );
+
+        self::assertNotFalse($supportingIndex);
+        self::assertNotFalse($oldUniqueDrop);
+        self::assertLessThan(
+            $oldUniqueDrop,
+            $supportingIndex,
+            'The standalone email index must exist before MySQL drops the unique index used by the foreign key.'
+        );
+    }
+}

--- a/database/migrations/2026_07_04_120000_complete_marketing_lifecycle_and_content_sources.php
+++ b/database/migrations/2026_07_04_120000_complete_marketing_lifecycle_and_content_sources.php
@@ -45,6 +45,15 @@ return new class extends Migration
                 if (! Schema::hasColumn('marketing_campaign_recipients', 'cycle_number')) {
                     $table->unsignedInteger('cycle_number')->default(1)->after('marketing_list_member_id');
                 }
+
+                // MySQL may use the old composite unique index to support the email foreign key.
+                // Keep a dedicated supporting index in place before replacing that unique index.
+                if (! Schema::hasIndex('marketing_campaign_recipients', 'marketing_campaign_recipients_email_index')) {
+                    $table->index(
+                        'marketing_campaign_email_id',
+                        'marketing_campaign_recipients_email_index'
+                    );
+                }
             });
 
             Schema::table('marketing_campaign_recipients', function (Blueprint $table): void {


### PR DESCRIPTION
## Summary

- creates a dedicated index for `marketing_campaign_email_id` before replacing the composite unique index
- prevents MySQL from rejecting the index drop when that index currently supports the foreign key
- adds a regression test that locks in the safe migration order

## Production finding

The release migration partially applied its additive columns, then stopped before replacing `marketing_campaign_recipient_member_unique`. The migration remains idempotent and can safely resume after this fix.

## Validation

- Marketing feature suite: 33 tests passed, 482 assertions
- Migration safety unit test: 1 test passed, 3 assertions