### PR TITLE
fix: BookStack API rate-limit handling (429 Too Many Attempts)

### DIFF
--- a/app/Modules/Integration/Actions/SyncBookStackToKnowledge.php
+++ b/app/Modules/Integration/Actions/SyncBookStackToKnowledge.php
@@ -50,7 +50,13 @@ class SyncBookStackToKnowledge
                 $summary[$result]++;
             } catch (\Throwable $exception) {
                 $summary['failed']++;
-                $summary['errors'][] = 'Page '.($pageId ?: 'unknown').': '.$exception->getMessage();
+                $message = $exception->getMessage();
+                if (str_contains($message, 'rate limit') || str_contains($message, '429') || str_contains($message, 'Too Many Attempts')) {
+                    $summary['rate_limited'] = ($summary['rate_limited'] ?? 0) + 1;
+                    $summary['errors'][] = 'Page '.$pageId.': RATE-LIMITED — '.$message;
+                } else {
+                    $summary['errors'][] = 'Page '.$pageId.': '.$message;
+                }
             }
         }
 
@@ -62,7 +68,9 @@ class SyncBookStackToKnowledge
         $this->integration->is_healthy = $summary['failed'] === 0;
         $this->integration->last_error = $summary['failed'] === 0
             ? null
-            : implode("\n", array_slice($summary['errors'], 0, 5));
+            : collect($summary['errors'])
+                ->take(5)
+                ->join("\n");
         $this->integration->save();
 
         return $summary;

--- a/app/Modules/Integration/Services/BookStack/BookStackClient.php
+++ b/app/Modules/Integration/Services/BookStack/BookStackClient.php
@@ -5,22 +5,47 @@ namespace App\Modules\Integration\Services\BookStack;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Sleep;
 use RuntimeException;
 
 class BookStackClient
 {
     private const PAGE_SIZE = 100;
 
+    /**
+     * Minimum seconds between API requests to stay under BookStack's rate limit.
+     * BookStack defaults to 180 requests/minute (3/sec); 350ms gives safe headroom.
+     */
+    private const DEFAULT_REQUEST_DELAY_SECONDS = 0.35;
+
+    /**
+     * Maximum retries for HTTP 429 (Too Many Attempts) responses.
+     */
+    private const MAX_RETRY_ATTEMPTS = 3;
+
+    /**
+     * Base delay in seconds for exponential backoff on 429 responses.
+     * Actual delay: base * 2^attempt (2s, 4s, 8s).
+     */
+    private const RETRY_BASE_DELAY_SECONDS = 2;
+
+    /**
+     * Timestamp of the last API request, used to enforce minimum inter-request delay.
+     */
+    private static float $lastRequestTime = 0.0;
+
     public function __construct(
         private readonly string $baseUrl,
         private readonly string $tokenId,
         private readonly string $tokenSecret,
+        private readonly float $requestDelaySeconds = self::DEFAULT_REQUEST_DELAY_SECONDS,
+        private readonly int $maxRetries = self::MAX_RETRY_ATTEMPTS,
     ) {}
 
     public function testConnection(): array
     {
         try {
-            $response = $this->request()->get($this->endpoint('/api/books'), [
+            $response = $this->getWithRateLimit('/api/books', [
                 'count' => 1,
             ]);
         } catch (ConnectionException $exception) {
@@ -60,7 +85,7 @@ class BookStackClient
      */
     public function readShelf(int|string $shelfId): array
     {
-        $response = $this->request()->get($this->endpoint('/api/shelves/'.$shelfId));
+        $response = $this->getWithRateLimit('/api/shelves/'.$shelfId);
 
         $this->ensureSuccessful($response, 'Unable to read BookStack shelf '.$shelfId);
 
@@ -84,7 +109,7 @@ class BookStackClient
      */
     public function readBook(int|string $bookId): array
     {
-        $response = $this->request()->get($this->endpoint('/api/books/'.$bookId));
+        $response = $this->getWithRateLimit('/api/books/'.$bookId);
 
         $this->ensureSuccessful($response, 'Unable to read BookStack book '.$bookId);
 
@@ -99,7 +124,7 @@ class BookStackClient
      */
     public function createShelf(array $payload): array
     {
-        $response = $this->request()->post($this->endpoint('/api/shelves'), $payload);
+        $response = $this->postWithRateLimit('/api/shelves', $payload);
 
         $this->ensureSuccessful($response, 'Unable to create BookStack shelf');
 
@@ -114,7 +139,7 @@ class BookStackClient
      */
     public function updateShelf(int|string $shelfId, array $payload): array
     {
-        $response = $this->request()->put($this->endpoint('/api/shelves/'.$shelfId), $payload);
+        $response = $this->putWithRateLimit('/api/shelves/'.$shelfId, $payload);
 
         $this->ensureSuccessful($response, 'Unable to update BookStack shelf '.$shelfId);
 
@@ -126,7 +151,7 @@ class BookStackClient
      */
     public function deleteShelf(int|string $shelfId): void
     {
-        $response = $this->request()->delete($this->endpoint('/api/shelves/'.$shelfId));
+        $response = $this->deleteWithRateLimit('/api/shelves/'.$shelfId);
 
         $this->ensureSuccessful($response, 'Unable to delete BookStack shelf '.$shelfId);
     }
@@ -139,7 +164,7 @@ class BookStackClient
      */
     public function createBook(array $payload): array
     {
-        $response = $this->request()->post($this->endpoint('/api/books'), $payload);
+        $response = $this->postWithRateLimit('/api/books', $payload);
 
         $this->ensureSuccessful($response, 'Unable to create BookStack book');
 
@@ -154,7 +179,7 @@ class BookStackClient
      */
     public function updateBook(int|string $bookId, array $payload): array
     {
-        $response = $this->request()->put($this->endpoint('/api/books/'.$bookId), $payload);
+        $response = $this->putWithRateLimit('/api/books/'.$bookId, $payload);
 
         $this->ensureSuccessful($response, 'Unable to update BookStack book '.$bookId);
 
@@ -166,7 +191,7 @@ class BookStackClient
      */
     public function deleteBook(int|string $bookId): void
     {
-        $response = $this->request()->delete($this->endpoint('/api/books/'.$bookId));
+        $response = $this->deleteWithRateLimit('/api/books/'.$bookId);
 
         if ($response->status() === 404) {
             return;
@@ -205,7 +230,7 @@ class BookStackClient
      */
     public function readChapter(int|string $chapterId): array
     {
-        $response = $this->request()->get($this->endpoint('/api/chapters/'.$chapterId));
+        $response = $this->getWithRateLimit('/api/chapters/'.$chapterId);
 
         $this->ensureSuccessful($response, 'Unable to read BookStack chapter '.$chapterId);
 
@@ -220,7 +245,7 @@ class BookStackClient
      */
     public function createChapter(array $payload): array
     {
-        $response = $this->request()->post($this->endpoint('/api/chapters'), $payload);
+        $response = $this->postWithRateLimit('/api/chapters', $payload);
 
         $this->ensureSuccessful($response, 'Unable to create BookStack chapter');
 
@@ -235,7 +260,7 @@ class BookStackClient
      */
     public function updateChapter(int|string $chapterId, array $payload): array
     {
-        $response = $this->request()->put($this->endpoint('/api/chapters/'.$chapterId), $payload);
+        $response = $this->putWithRateLimit('/api/chapters/'.$chapterId, $payload);
 
         $this->ensureSuccessful($response, 'Unable to update BookStack chapter '.$chapterId);
 
@@ -247,7 +272,7 @@ class BookStackClient
      */
     public function deleteChapter(int|string $chapterId): void
     {
-        $response = $this->request()->delete($this->endpoint('/api/chapters/'.$chapterId));
+        $response = $this->deleteWithRateLimit('/api/chapters/'.$chapterId);
 
         if ($response->status() === 404) {
             return;
@@ -265,12 +290,11 @@ class BookStackClient
         $offset = 0;
 
         do {
-            $response = $this->request()
-                ->get($this->endpoint($path), [
-                    'count' => self::PAGE_SIZE,
-                    'offset' => $offset,
-                    'sort' => '+id',
-                ]);
+            $response = $this->getWithRateLimit($path, [
+                'count' => self::PAGE_SIZE,
+                'offset' => $offset,
+                'sort' => '+id',
+            ]);
 
             $this->ensureSuccessful($response, $failureMessage);
 
@@ -296,7 +320,7 @@ class BookStackClient
      */
     public function readPage(int|string $pageId): array
     {
-        $response = $this->request()->get($this->endpoint('/api/pages/'.$pageId));
+        $response = $this->getWithRateLimit('/api/pages/'.$pageId);
 
         $this->ensureSuccessful($response, 'Unable to read BookStack page '.$pageId);
 
@@ -311,7 +335,7 @@ class BookStackClient
      */
     public function createPage(array $payload): array
     {
-        $response = $this->request()->post($this->endpoint('/api/pages'), $payload);
+        $response = $this->postWithRateLimit('/api/pages', $payload);
 
         $this->ensureSuccessful($response, 'Unable to create BookStack page');
 
@@ -326,7 +350,7 @@ class BookStackClient
      */
     public function updatePage(int|string $pageId, array $payload): array
     {
-        $response = $this->request()->put($this->endpoint('/api/pages/'.$pageId), $payload);
+        $response = $this->putWithRateLimit('/api/pages/'.$pageId, $payload);
 
         $this->ensureSuccessful($response, 'Unable to update BookStack page '.$pageId);
 
@@ -338,7 +362,7 @@ class BookStackClient
      */
     public function deletePage(int|string $pageId): void
     {
-        $response = $this->request()->delete($this->endpoint('/api/pages/'.$pageId));
+        $response = $this->deleteWithRateLimit('/api/pages/'.$pageId);
 
         if ($response->status() === 404) {
             return;
@@ -347,6 +371,12 @@ class BookStackClient
         $this->ensureSuccessful($response, 'Unable to delete BookStack page '.$pageId);
     }
 
+    /**
+     * Build the base HTTP request with authentication headers.
+     *
+     * Does NOT send the request — callers chain ->get()/->post()/etc.
+     * Rate-limit delay is applied in sendWithRateLimit().
+     */
     private function request()
     {
         return Http::acceptJson()
@@ -355,6 +385,145 @@ class BookStackClient
                 'Authorization' => 'Token '.$this->tokenId.':'.$this->tokenSecret,
             ])
             ->timeout(15);
+    }
+
+    /**
+     * Send a GET request with inter-request delay and 429 retry/backoff.
+     *
+     * @param  string  $path  API endpoint path (e.g. '/api/pages')
+     * @param  array<string,mixed>  $query  Query parameters
+     * @return Response
+     *
+     * @throws RuntimeException On non-2xx responses after exhausting retries
+     * @throws ConnectionException On network failures
+     */
+    private function getWithRateLimit(string $path, array $query = []): Response
+    {
+        return $this->sendWithRateLimit('GET', $path, $query);
+    }
+
+    /**
+     * Send a POST request with inter-request delay and 429 retry/backoff.
+     *
+     * @param  string  $path  API endpoint path
+     * @param  array<string,mixed>  $payload  JSON body
+     * @return Response
+     *
+     * @throws RuntimeException On non-2xx responses after exhausting retries
+     * @throws ConnectionException On network failures
+     */
+    private function postWithRateLimit(string $path, array $payload = []): Response
+    {
+        return $this->sendWithRateLimit('POST', $path, [], $payload);
+    }
+
+    /**
+     * Send a PUT request with inter-request delay and 429 retry/backoff.
+     *
+     * @param  string  $path  API endpoint path
+     * @param  array<string,mixed>  $payload  JSON body
+     * @return Response
+     *
+     * @throws RuntimeException On non-2xx responses after exhausting retries
+     * @throws ConnectionException On network failures
+     */
+    private function putWithRateLimit(string $path, array $payload = []): Response
+    {
+        return $this->sendWithRateLimit('PUT', $path, [], $payload);
+    }
+
+    /**
+     * Send a DELETE request with inter-request delay and 429 retry/backoff.
+     *
+     * @param  string  $path  API endpoint path
+     * @return Response
+     *
+     * @throws RuntimeException On non-2xx responses after exhausting retries
+     * @throws ConnectionException On network failures
+     */
+    private function deleteWithRateLimit(string $path): Response
+    {
+        return $this->sendWithRateLimit('DELETE', $path);
+    }
+
+    /**
+     * Core request sender with inter-request pacing and 429 exponential backoff.
+     *
+     * Enforces a minimum delay between requests (DEFAULT_REQUEST_DELAY_SECONDS)
+     * to stay under BookStack's 180 req/min rate limit. On HTTP 429, retries
+     * with exponential backoff up to maxRetries attempts.
+     *
+     * @param  'GET'|'POST'|'PUT'|'DELETE'  $method
+     * @param  string  $path  API endpoint path
+     * @param  array<string,mixed>  $query  Query parameters (GET only)
+     * @param  array<string,mixed>  $payload  JSON body (POST/PUT only)
+     *
+     * @throws RuntimeException On non-429 failures or after exhausting 429 retries
+     * @throws ConnectionException On network failures
+     */
+    private function sendWithRateLimit(string $method, string $path, array $query = [], array $payload = []): Response
+    {
+        $url = $this->endpoint($path);
+        $attempts = 0;
+
+        while (true) {
+            $this->paceRequest();
+
+            $request = $this->request();
+
+            $response = match ($method) {
+                'GET' => $request->get($url, $query),
+                'POST' => $request->post($url, $payload),
+                'PUT' => $request->put($url, $payload),
+                'DELETE' => $request->delete($url),
+            };
+
+            $attempts++;
+
+            if ($response->status() === 429) {
+                if ($attempts >= $this->maxRetries) {
+                    $retryAfter = $response->header('Retry-After');
+                    $waited = self::RETRY_BASE_DELAY_SECONDS * (2 ** $this->maxRetries);
+                    throw new RuntimeException(
+                        "BookStack API rate limit exceeded after {$attempts} attempts"
+                        ." (waited ~{$waited}s total). Consider increasing sync_interval_minutes"
+                        ." or reducing the number of synced pages."
+                        .($retryAfter ? " Retry-After header: {$retryAfter}s." : '')
+                    );
+                }
+
+                $backoffSeconds = self::RETRY_BASE_DELAY_SECONDS * (2 ** ($attempts - 1));
+                $retryAfter = $response->header('Retry-After');
+
+                if ($retryAfter && is_numeric($retryAfter)) {
+                    $backoffSeconds = max($backoffSeconds, (float) $retryAfter);
+                }
+
+                Sleep::for($backoffSeconds)->seconds();
+
+                continue;
+            }
+
+            return $response;
+        }
+    }
+
+    /**
+     * Enforce minimum inter-request delay by sleeping if the last request was too recent.
+     *
+     * BookStack's default rate limit is 180 requests/minute (3/sec).
+     * A 350ms delay between requests provides safe headroom.
+     */
+    private function paceRequest(): void
+    {
+        $elapsed = microtime(true) - self::$lastRequestTime;
+
+        if ($elapsed < $this->requestDelaySeconds && self::$lastRequestTime > 0) {
+            $sleepSeconds = $this->requestDelaySeconds - $elapsed;
+            usleep((int) ($sleepSeconds * 1_000_000));
+        }
+
+        self::$lastRequestTime = microtime(true);
     }
 
     private function endpoint(string $path): string


### PR DESCRIPTION
## Problem

BookStack pull sync fails on pages 35, 37, 39, 42, 44 with "Too Many Attempts" errors. Root cause: `BookStackClient` had zero rate-limit awareness — no inter-request delay, no 429 retry, no backoff.

## Changes

### `BookStackClient.php`
- **`paceRequest()`** — Enforces 350ms minimum delay between API requests (configurable)
- **`sendWithRateLimit()`** — Core sender with 429 exponential backoff (2s, 4s, 8s)
- **`getWithRateLimit/postWithRateLimit/putWithRateLimit/deleteWithRateLimit`** — Typed wrappers for each HTTP method
- **`Retry-After` header** respected when BookStack includes it
- **All 16 public methods** migrated from raw `$this->request()->method()` to rate-limited wrappers
- Constructor extended with optional `$requestDelaySeconds` and `$maxRetries` params

### `SyncBookStackToKnowledge.php`
- Rate-limit errors now tagged with `RATE-LIMITED` prefix in error messages
- New `rate_limited` counter in sync summary
- Cleaner error formatting with `collect()->take()->join()`

## Constants

| Constant | Value | Purpose |
|---|---|---|
| `DEFAULT_REQUEST_DELAY_SECONDS` | 0.35 | 350ms between requests (180/min = 3/sec) |
| `MAX_RETRY_ATTEMPTS` | 3 | Max 429 retries before failure |
| `RETRY_BASE_DELAY_SECONDS` | 2 | Exponential backoff base |

## Backward Compatibility
- No breaking changes — constructor params are optional with safe defaults
- No database migrations needed
- No API surface changes

## Related
- Fixes issue #196